### PR TITLE
fix: hotfix region type

### DIFF
--- a/snakemake_executor_plugin_aws_batch/__init__.py
+++ b/snakemake_executor_plugin_aws_batch/__init__.py
@@ -28,7 +28,7 @@ from snakemake_interface_common.exceptions import WorkflowError
 # of None or anything else that makes sense in your case.
 @dataclass
 class ExecutorSettings(ExecutorSettingsBase):
-    region: Optional[int] = field(
+    region: Optional[str] = field(
         default=None,
         metadata={
             "help": "AWS Region",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated AWS Batch region configuration. The region setting now accepts standard string values (e.g., "us-west-2") instead of integers, with the default remaining unchanged. End users will notice improved consistency with AWS naming conventions. This enhancement ensures that configuring AWS regions aligns with industry standards and reduces potential misconfiguration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->