### PR TITLE
fix: bump s3, add true storage test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ flake8 = "^6.1.0"
 coverage = "^7.3.2"
 pytest = "^7.4.3"
 snakemake = "^8.20.1"
-snakemake-storage-plugin-s3 = "^0.2.7"
+snakemake-storage-plugin-s3 = "^0.3.0"
 
 [tool.coverage.run]
 omit = [".*", "*/site-packages/*", "Snakefile"]

--- a/snakemake_executor_plugin_aws_batch/batch_job_builder.py
+++ b/snakemake_executor_plugin_aws_batch/batch_job_builder.py
@@ -1,6 +1,6 @@
 import uuid
 from typing import List
-from snakemake.exceptions import WorkflowError
+from snakemake_interface_common.exceptions import WorkflowError
 from snakemake_interface_executor_plugins.jobs import JobExecutorInterface
 from snakemake_executor_plugin_aws_batch.batch_client import BatchClient
 from snakemake_executor_plugin_aws_batch.constant import (

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,70 +1,15 @@
 import os
-import uuid
-from typing import Optional, Mapping
 
 import snakemake.common.tests
 from snakemake_interface_executor_plugins.settings import ExecutorSettingsBase
 from snakemake_executor_plugin_aws_batch import ExecutorSettings
-from snakemake.common.tests import TestWorkflowsBase as TestWorkflowsBase
+from snakemake.common.tests import TestWorkflowsMinioPlayStorageBase
+from typing import Optional
 from snakemake_interface_common.plugin_registry.plugin import TaggedSettings
-from snakemake_interface_common.utils import lazy_property
+from typing import Mapping
 
 
-class TestWorkflowsMinioLocalStorageBase(TestWorkflowsBase):
-    def get_default_storage_provider(self) -> Optional[str]:
-        return "s3"
-
-    def get_default_storage_prefix(self) -> Optional[str]:
-        return f"s3://{self.bucket}"
-
-    def get_default_storage_provider_settings(
-        self,
-    ) -> Optional[Mapping[str, TaggedSettings]]:
-        from snakemake_storage_plugin_s3 import StorageProviderSettings
-
-        self._storage_provider_settings = StorageProviderSettings(
-            endpoint_url=self.endpoint_url,
-            access_key=self.access_key,
-            secret_key=self.secret_key,
-        )
-
-        tagged_settings = TaggedSettings()
-        tagged_settings.register_settings(self._storage_provider_settings)
-        return {"s3": tagged_settings}
-
-    def cleanup_test(self):
-        import boto3
-
-        # clean up using boto3
-        s3c = boto3.resource(
-            "s3",
-            endpoint_url=self.endpoint_url,
-            aws_access_key_id=self.access_key,
-            aws_secret_access_key=self.secret_key,
-        )
-        try:
-            s3c.Bucket(self.bucket).delete()
-        except Exception:
-            pass
-
-    @lazy_property
-    def bucket(self):
-        return f"snakemake-{uuid.uuid4().hex}"
-
-    @property
-    def endpoint_url(self):
-        return "http://127.0.0.1:9000"
-
-    @property
-    def access_key(self):
-        return "minio"
-
-    @property
-    def secret_key(self):
-        return "minio123"
-
-
-class TestWorkflowsBase(TestWorkflowsMinioLocalStorageBase):
+class TestWorkflowsBase(TestWorkflowsMinioPlayStorageBase):
     def get_executor(self) -> str:
         return "aws-batch"
 
@@ -85,3 +30,20 @@ class TestWorkflowsBase(TestWorkflowsMinioLocalStorageBase):
             seconds_between_status_checks=5,
             envvars=self.get_envvars(),
         )
+
+
+class TestWorkflowsTrueStorageBase(TestWorkflowsBase):
+    def get_default_storage_provider_settings(
+        self,
+    ) -> Optional[Mapping[str, TaggedSettings]]:
+        from snakemake_storage_plugin_s3 import StorageProviderSettings
+
+        self._storage_provider_settings = StorageProviderSettings(
+            region=os.getenv("SNAKEMAKE_STORAGE_S3_REGION"),
+            access_key=os.getenv("SNAKEMAKE_STORAGE_S3_ACCESS_KEY"),
+            secret_key=os.getenv("SNAKEMAKE_STORAGE_S3_SECRET_KEY"),
+        )
+
+        tagged_settings = TaggedSettings()
+        tagged_settings.register_settings(self._storage_provider_settings)
+        return {"s3": tagged_settings}

--- a/tests/tests_true_api.py
+++ b/tests/tests_true_api.py
@@ -1,5 +1,5 @@
-from tests import TestWorkflowsBase
+from tests import TestWorkflowsTrueStorageBase
 
 
-class TestWorkflowsTrueApi(TestWorkflowsBase):
+class TestWorkflowsTrueApi(TestWorkflowsTrueStorageBase):
     __test__ = True


### PR DESCRIPTION
This PR cleans up TestWorkflowsBase classes and fixes test_true_api

Depends on https://github.com/snakemake/snakemake-storage-plugin-s3/pull/42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests / Refactor**
  - Revised the internal test framework to use environment-based storage configuration instead of static settings.
  - Reorganized the test structure for improved clarity and adaptability, ensuring more robust validation of storage-related features.
  - Updated exception handling by modifying the source module for `WorkflowError`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->