### PR TITLE
docs: terraform

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -118,6 +118,8 @@ resource "aws_batch_compute_environment" "sample" {
     max_vcpus = var.max_vcpus
     min_vcpus = var.min_vcpus
 
+    allocation_strategy = var.aws_batch_compute_resource_allocation_strategy
+
     placement_group = aws_placement_group.sample.name
 
     security_group_ids = [aws_security_group.sg01.id]
@@ -142,4 +144,10 @@ resource "aws_batch_job_queue" "snakequeue" {
     order               = 1
     compute_environment = aws_batch_compute_environment.sample.arn
   }
+
+  # placeholder for additional compute environment
+  # compute_environment_order {
+  #   order               = 2
+  #   compute_environment = aws_batch_compute_environment02.sample.arn
+  # }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -151,3 +151,15 @@ resource "aws_batch_job_queue" "snakequeue" {
   #   compute_environment = aws_batch_compute_environment02.sample.arn
   # }
 }
+
+output "SNAKEMAKE_AWS_BATCH_REGION" {
+  value = var.aws_provider_region
+}
+
+output "SNAKEMAKE_AWS_BATCH_JOB_QUEUE" {
+  value = aws_batch_job_queue.snakequeue.arn
+}
+
+output "SNAKEMAKE_AWS_BATCH_JOB_ROLE" {
+  value = aws_iam_role.aws_batch_service_role.arn
+}

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -68,7 +68,7 @@ variable "aws_batch_compute_environment_name" {
 variable "instance_types" {
   description = "The allowed instance types for the compute environment"
   type        = list(string)
-  default     = ["c4.large"]
+  default     = ["c4.xlarge"]
   # , "c4.xlarge", "c4.2xlarge", "c4.4xlarge", "c4.8xlarge"]
 }
 
@@ -94,6 +94,12 @@ variable "aws_batch_compute_environment_type" {
   description = "The type of the AWS Batch compute environment"
   type        = string
   default     = "MANAGED"
+}
+
+variable "aws_batch_compute_resource_allocation_strategy" {
+  description = "The allocation strategy of the AWS Batch compute environment"
+  type        = string
+  default     = "BEST_FIT"
 }
 
 variable "aws_batch_job_queue_name" {

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -68,8 +68,8 @@ variable "aws_batch_compute_environment_name" {
 variable "instance_types" {
   description = "The allowed instance types for the compute environment"
   type        = list(string)
-  default     = ["c4.xlarge"]
-  # , "c4.xlarge", "c4.2xlarge", "c4.4xlarge", "c4.8xlarge"]
+  default     = ["c5.xlarge"]
+  # , "c5.large", "c5.2xlarge", "c5.4xlarge", "c5.8xlarge"]
 }
 
 variable "max_vcpus" {


### PR DESCRIPTION
This PR updates terraform
-  to output environment variables for consumption by executor configuration
- to use c5 machine types as default in vars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced AWS Batch configuration with a new allocation strategy parameter for optimized resource handling.
  - Upgraded default compute instance selection to a newer, higher-performance series.
  - Added outputs for AWS Batch Region, Job Queue, and Job Role, improving visibility of essential setup details.
  - Prepared groundwork for future expansion of compute environment capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->