### PR TITLE
ci: get release-please-action to existing version 4

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
-      - uses: googleapis/release-please-action@v17
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: python


### PR DESCRIPTION
The maximum of the action currently is `4.2.0`:
https://github.com/googleapis/release-please-action/releases