### PR TITLE
fix: Convert `log_info` dict to string for logging

### DIFF
--- a/snakemake_executor_plugin_aws_batch/__init__.py
+++ b/snakemake_executor_plugin_aws_batch/__init__.py
@@ -228,7 +228,7 @@ class Executor(RemoteExecutor):
                     "job_id": job.external_jobid,
                     "status": job_status,
                 }
-                self.logger.debug(log_info)
+                self.logger.debug(str(log_info))
                 return None, None
         except Exception as e:
             self.logger.error(f"Error getting job status: {e}")


### PR DESCRIPTION
In a recent release of snakemake, passing a dict to the logger spits out an error like the following: 
```
Monitoring 1 active Batch jobs
--- Logging error ---
Traceback (most recent call last):
  File "/opt/conda/envs/snakemake/lib/python3.13/logging/__init__.py", line 1154, in emit
    stream.write(msg + self.terminator)
                 ~~~~^~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for +: 'dict' and 'str'
Call stack:
  File "/opt/conda/envs/snakemake/lib/python3.13/threading.py", line 1014, in _bootstrap
    self._bootstrap_inner()
  File "/opt/conda/envs/snakemake/lib/python3.13/threading.py", line 1043, in _bootstrap_inner
    self.run()
  File "/opt/conda/envs/snakemake/lib/python3.13/threading.py", line 994, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/conda/envs/snakemake/lib/python3.13/site-packages/snakemake_interface_executor_plugins/executors/remote.py", line 195, in _wait_thread
    asyncio.run(self._wait_for_jobs())
  File "/opt/conda/envs/snakemake/lib/python3.13/asyncio/runners.py", line 195, in run
    return runner.run(main)
  File "/opt/conda/envs/snakemake/lib/python3.13/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
  File "/opt/conda/envs/snakemake/lib/python3.13/asyncio/base_events.py", line 712, in run_until_complete
    self.run_forever()
  File "/opt/conda/envs/snakemake/lib/python3.13/asyncio/base_events.py", line 683, in run_forever
    self._run_once()
  File "/opt/conda/envs/snakemake/lib/python3.13/asyncio/base_events.py", line 2050, in _run_once
    handle._run()
  File "/opt/conda/envs/snakemake/lib/python3.13/asyncio/events.py", line 89, in _run
    self._context.run(self._callback, *self._args)
  File "/opt/conda/envs/snakemake/lib/python3.13/site-packages/snakemake_interface_executor_plugins/executors/remote.py", line 185, in _wait_for_jobs
    still_active_jobs = [
  File "/opt/conda/envs/snakemake/lib/python3.13/site-packages/snakemake_executor_plugin_aws_batch/__init__.py", line 187, in check_active_jobs
    status_code, msg = self._get_job_status(job)
  File "/opt/conda/envs/snakemake/lib/python3.13/site-packages/snakemake_executor_plugin_aws_batch/__init__.py", line 231, in _get_job_status
    self.logger.debug(log_info)
Message: {'job_name': 'snakejob-job_name-bc62ge46-bc1a-4348-9f1f-28bd4d074dc8', 'job_id': '3ff6de37-cc9d-493a-8b78-4d6173ac4079', 'status': 'RUNNING'}
Arguments: ()
```
This change resolves to the previous functionality of just printing the dict as a string:
```
Monitoring 1 active Batch jobs
{'job_name': 'snakejob-job_name-bc62ge46-bc1a-4348-9f1f-28bd4d074dc8', 'job_id': '3ff6de37-cc9d-493a-8b78-4d6173ac4079', 'status': 'RUNNING'}
```
I haven't dug into what specific change in `snakemake` caused the deviation in handling, but I suspect it was in [release v9.11.1](https://github.com/snakemake/snakemake/releases/tag/v9.11.3), which lists "logging refinements" in its changelog. It doesn't actually affect workflow execution, but it pollutes the log with these error messages. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Improved debug logging by formatting complex data as strings, resulting in cleaner, more readable job status entries.
  - Enhances troubleshooting and compatibility with log aggregation tools through more consistent log output.
  - Reduces noisy or hard-to-parse debug messages.
  - No changes to workflow execution, behavior, or results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->