### PR TITLE
feat: add rule-specific container configuration option (#30)

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -28,6 +28,24 @@ SNAKEMAKE_AWS_BATCH_REGION
 SNAKEMAKE_AWS_BATCH_JOB_QUEUE
 SNAKEMAKE_AWS_BATCH_JOB_ROLE
 
+# Rule-Specific Container Images
+
+By default, all jobs use the global container image specified via `--container-image`. However, you can specify a different container image for individual rules using the `aws_batch_container_image` resource parameter:
+
+```python
+rule my_rule:
+    input:
+        "input.txt"
+    output:
+        "output.txt"
+    resources:
+        aws_batch_container_image="my-custom-image:tag"
+    shell:
+        "process_data.sh {input} {output}"
+```
+
+This allows you to use different containers with specialized tools for different rules within the same workflow, rather than requiring all tools to be present in a single container.
+
 # Example
 
 ## Create environment

--- a/docs/further.md
+++ b/docs/further.md
@@ -46,6 +46,12 @@ rule my_rule:
 
 This allows you to use different containers with specialized tools for different rules within the same workflow, rather than requiring all tools to be present in a single container.
 
+Each rule-specific image must still satisfy the same requirements as the global
+container image (see [Container Image Requirements](#container-image-requirements)
+below): the worker runs `snakemake` inside the container, so the image must have
+Snakemake and a compatible storage plugin installed. A plain tool image that does
+not include Snakemake will fail to launch the job.
+
 # Example
 
 ## Create environment

--- a/snakemake_executor_plugin_aws_batch/__init__.py
+++ b/snakemake_executor_plugin_aws_batch/__init__.py
@@ -132,11 +132,17 @@ class Executor(RemoteExecutor):
         # argument 'external_job_id'.
 
         try:
+            # Use rule-level container image if specified via resources,
+            # otherwise fall back to global container image
+            container_image = job.resources.get(
+                "aws_batch_container_image", self.container_image
+            )
+
             job_definition = BatchJobBuilder(
                 logger=self.logger,
                 job=job,
                 envvars=self.envvars(),
-                container_image=self.container_image,
+                container_image=container_image,
                 settings=self.settings,
                 job_command=self.format_job_exec(job),
                 batch_client=self.batch_client,

--- a/snakemake_executor_plugin_aws_batch/__init__.py
+++ b/snakemake_executor_plugin_aws_batch/__init__.py
@@ -153,11 +153,17 @@ class Executor(RemoteExecutor):
         # argument 'external_job_id'.
 
         try:
+            # Use rule-level container image if specified via resources,
+            # otherwise fall back to global container image
+            container_image = job.resources.get(
+                "aws_batch_container_image", self.container_image
+            )
+
             job_definition = BatchJobBuilder(
                 logger=self.logger,
                 job=job,
                 envvars=self.envvars(),
-                container_image=self.container_image,
+                container_image=container_image,
                 settings=self.settings,
                 job_command=self.format_job_exec(job),
                 batch_client=self.batch_client,

--- a/tests/test_batch_job_builder.py
+++ b/tests/test_batch_job_builder.py
@@ -977,3 +977,57 @@ class TestSubmitSchedulingPriority:
         )
         call_args = _run_submit_priority(builder)
         assert call_args.kwargs["schedulingPriorityOverride"] == 9999
+
+
+# ---------------------------------------------------------------------------
+# Tests for the per-rule aws_batch_container_image resource (Executor.run_job)
+# ---------------------------------------------------------------------------
+
+
+def _run_job_capture_container_image(
+    resources: dict, global_image: str = "global-image:latest"
+) -> str:
+    """Call Executor.run_job with the given job.resources (BatchJobBuilder mocked)
+    and return the container_image it passed to BatchJobBuilder."""
+    from snakemake_executor_plugin_aws_batch import Executor
+
+    executor = object.__new__(Executor)
+    executor.logger = MagicMock()
+    executor.batch_client = MagicMock()
+    executor.settings = SimpleNamespace(
+        job_queue="test-queue", job_role="test-role", tags=None, task_timeout=None
+    )
+    executor.container_image = global_image
+    executor.envvars = MagicMock(return_value={})
+    executor.format_job_exec = MagicMock(return_value="snakemake ...")
+    executor.report_job_submission = MagicMock()
+
+    job = MagicMock()
+    job.resources = resources
+
+    with patch("snakemake_executor_plugin_aws_batch.BatchJobBuilder") as mock_cls:
+        instance = mock_cls.return_value
+        instance.submit.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+            "jobQueue": "test-queue",
+        }
+        instance.job_queue = "test-queue"
+        executor.run_job(job)
+    return mock_cls.call_args.kwargs["container_image"]
+
+
+class TestRunJobContainerImage:
+    """Executor.run_job resolves the per-rule aws_batch_container_image resource."""
+
+    def test_rule_resource_overrides_global_image(self):
+        """The aws_batch_container_image resource must override the global image."""
+        image = _run_job_capture_container_image(
+            {"aws_batch_container_image": "rule-image:v2"}
+        )
+        assert image == "rule-image:v2"
+
+    def test_falls_back_to_global_when_resource_absent(self):
+        """With no per-rule resource, run_job must use the global container image."""
+        image = _run_job_capture_container_image({})
+        assert image == "global-image:latest"


### PR DESCRIPTION
This PR adds a resource configuration item `aws_batch_container_image` that can be used to customize the container any given rule uses when running on AWS Batch. As discussed in #30 and #31, currently it's possible to specify a container image that every rule in a workflow uses, and if you want to run an individual rule in a different container you have use apptainer, with some extra hoops if you need to authenticate with a private registry (eg. ECR).

There is a bit of a catch however - you need to base your image on the snakemake docker image. I don't think this is something that would be easy to work around and probably not a good fit with snakemake's design. I can update the documentation if this is  going to be merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Rules can now override the global container image by specifying a per-job container image.
  * If no per-job image is provided, the executor continues using the existing default image.

* **Documentation**
  * Added a new “Rule-Specific Container Images” section with configuration details and a Python Snakemake example.

* **Tests**
  * Added coverage to verify per-rule container image selection and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->