### PR TITLE
feat: per-rule queues, per-job tags, EC2/Fargate-aware validation

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -65,10 +65,65 @@ snakemake --jobs 4 \
     --verbose
 ```
 
+# Container Image Requirements
 
+The plugin does **not** auto-deploy the default storage provider to workers
+(`auto_deploy_default_storage_provider=False`): workers no longer run
+`pip install snakemake-storage-plugin-s3` at startup, because that pulls an
+unpinned version whose newer releases require snakemake >= 9 and break
+workers running snakemake 8.x. The container image used for jobs must
+therefore pre-install a compatible version of the storage plugin (e.g.
+`snakemake-storage-plugin-s3`) alongside snakemake itself. Image maintainers
+are responsible for pinning a plugin version compatible with the snakemake
+version in the image.
 
+# Per-Rule Job Queues
 
+By default all jobs are submitted to the queue given by
+`--aws-batch-job-queue`. A rule can override this with the `batch_queue`
+resource, e.g. to route jobs to a queue wired to a different compute
+environment (ARM vs x86, GPU vs CPU):
 
+```python
+rule align:
+    resources:
+        batch_queue="arn:aws:batch:us-west-2:123456789012:job-queue/arm-queue"
+    ...
+```
 
+Platform detection and job submission both use the resolved per-rule queue.
 
+# Shared Memory (`/dev/shm`)
 
+On EC2/ECS containers `/dev/shm` defaults to 64 MB, which is too small for
+tools that stage large in-memory indexes (e.g. bwa-mem2 shared-memory
+indexes). A rule can enlarge it via the `shared_memory_size_mb` resource:
+
+```python
+rule align:
+    resources:
+        shared_memory_size_mb=4096
+    ...
+```
+
+This sets `linuxParameters.sharedMemorySize` on the job definition. It only
+applies on EC2 queues — Fargate does not honor
+`linuxParameters.sharedMemorySize`, so the resource is ignored there.
+
+# Job Tags
+
+Tags from `--aws-batch-tags` are applied to every job definition and job
+submitted by the plugin. In addition, dynamic tags can be supplied via the
+`SNAKEMAKE_AWS_BATCH_JOB_TAGS` environment variable as comma-separated
+`KEY=VALUE` pairs:
+
+```bash
+export SNAKEMAKE_AWS_BATCH_JOB_TAGS="run_id=2024-06-01,team=genomics"
+```
+
+Environment variable tags are merged with `--aws-batch-tags` and take
+precedence on key conflicts. This enables per-run cost tracking: a
+coordinator job can set the variable so that all child jobs it submits
+inherit the run-specific tags. AWS Batch allows at most 50 tags per job;
+malformed pairs (missing `=` or an empty key) raise an error at submission
+time.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ boto3 = "^1.36.5"
 python = "^3.11"
 snakemake-interface-common = "^1.17.4"
 snakemake-interface-executor-plugins = "^9.3.2"
-snakemake-storage-plugin-s3 = "^0.3.1"
+snakemake-storage-plugin-s3 = ">=0.2,<0.4"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.11.0"

--- a/snakemake_executor_plugin_aws_batch/__init__.py
+++ b/snakemake_executor_plugin_aws_batch/__init__.py
@@ -99,8 +99,12 @@ common_settings = CommonSettings(
     # and pass them e.g. as secrets to the execution backend)
     pass_envvar_declarations_to_cmd=False,
     # whether the default storage provider shall be deployed before the job is run on
-    # the remote node. Usually set to True if the executor does not assume a shared fs
-    auto_deploy_default_storage_provider=True,
+    # the remote node. Set to False so workers do NOT `pip install
+    # snakemake-storage-plugin-s3` at startup: that pulls unpinned versions whose
+    # newer PyPI metadata requires snakemake-interface-storage-plugins >= 4 and
+    # breaks snakemake 8.x. Users must pre-install a compatible plugin version
+    # in the container image.
+    auto_deploy_default_storage_provider=False,
     # specify initial amount of seconds to sleep before checking for job status
     init_seconds_before_status_checks=0,
 )
@@ -146,9 +150,9 @@ class Executor(RemoteExecutor):
             )
             job_info = job_definition.submit()
             log_info = {
-                "job_name:": job_info["jobName"],
+                "job_name": job_info["jobName"],
                 "jobId": job_info["jobId"],
-                "job_queue": self.settings.job_queue,
+                "job_queue": job_definition.job_queue,
             }
             self.logger.debug(f"AWS Batch job submitted: {log_info}")
         except Exception as e:

--- a/snakemake_executor_plugin_aws_batch/batch_client.py
+++ b/snakemake_executor_plugin_aws_batch/batch_client.py
@@ -72,3 +72,21 @@ class BatchClient:
         :return: The response from the terminate_job method.
         """
         return self.client.terminate_job(**kwargs)
+
+    def describe_job_queues(self, **kwargs):
+        """
+        Describe job queues in AWS Batch.
+
+        :param kwargs: The keyword arguments to pass to the describe_job_queues method.
+        :return: The response from the describe_job_queues method.
+        """
+        return self.client.describe_job_queues(**kwargs)
+
+    def describe_compute_environments(self, **kwargs):
+        """
+        Describe compute environments in AWS Batch.
+
+        :param kwargs: The keyword arguments to pass to the describe_compute_environments method.
+        :return: The response from the describe_compute_environments method.
+        """
+        return self.client.describe_compute_environments(**kwargs)

--- a/snakemake_executor_plugin_aws_batch/batch_client.py
+++ b/snakemake_executor_plugin_aws_batch/batch_client.py
@@ -72,3 +72,22 @@ class BatchClient:
         :return: The response from the terminate_job method.
         """
         return self.client.terminate_job(**kwargs)
+
+    def describe_job_queues(self, **kwargs):
+        """
+        Describe job queues in AWS Batch.
+
+        :param kwargs: The keyword arguments to pass to the describe_job_queues method.
+        :return: The response from the describe_job_queues method.
+        """
+        return self.client.describe_job_queues(**kwargs)
+
+    def describe_compute_environments(self, **kwargs):
+        """
+        Describe compute environments in AWS Batch.
+
+        :param kwargs: The keyword arguments to pass to
+            describe_compute_environments.
+        :return: The response from the describe_compute_environments method.
+        """
+        return self.client.describe_compute_environments(**kwargs)

--- a/snakemake_executor_plugin_aws_batch/batch_job_builder.py
+++ b/snakemake_executor_plugin_aws_batch/batch_job_builder.py
@@ -30,6 +30,8 @@ class BatchJobBuilder:
         self.job_command = job_command
         self.batch_client = batch_client
         self.created_job_defs = []
+        # Determine platform from job queue
+        self.platform = self._get_platform_from_queue()
 
     def _make_container_command(self, remote_command: str) -> List[str]:
         """
@@ -37,26 +39,115 @@ class BatchJobBuilder:
         """
         return ["/bin/bash", "-c", remote_command]
 
-    def _validate_resources(self, vcpu: str, mem: str) -> tuple[str, str]:
-        """Validates vcpu and meme conform to Batch EC2 cpu/mem relationship
-
-        https://docs.aws.amazon.com/batch/latest/APIReference/API_ResourceRequirement.html
+    def _get_platform_from_queue(self) -> str:
         """
-        vcpu = int(vcpu)
-        mem = int(mem)
+        Determine the platform (EC2 or FARGATE) from the job queue's compute environments.
 
+        :return: Platform capability string (EC2 or FARGATE)
+        """
+        try:
+            # Query the job queue
+            queue_response = self.batch_client.describe_job_queues(
+                jobQueues=[self.settings.job_queue]
+            )
+
+            if not queue_response.get("jobQueues"):
+                self.logger.warning(
+                    f"Job queue {self.settings.job_queue} not found. Defaulting to EC2."
+                )
+                return BATCH_JOB_PLATFORM_CAPABILITIES.EC2.value
+
+            job_queue = queue_response["jobQueues"][0]
+            compute_env_order = job_queue.get("computeEnvironmentOrder", [])
+
+            if not compute_env_order:
+                self.logger.warning(
+                    f"No compute environments found for queue {self.settings.job_queue}. "
+                    "Defaulting to EC2."
+                )
+                return BATCH_JOB_PLATFORM_CAPABILITIES.EC2.value
+
+            # Get the first compute environment ARN
+            compute_env_arn = compute_env_order[0]["computeEnvironment"]
+
+            # Query the compute environment to get its type
+            env_response = self.batch_client.describe_compute_environments(
+                computeEnvironments=[compute_env_arn]
+            )
+
+            if not env_response.get("computeEnvironments"):
+                self.logger.warning(
+                    f"Compute environment {compute_env_arn} not found. Defaulting to EC2."
+                )
+                return BATCH_JOB_PLATFORM_CAPABILITIES.EC2.value
+
+            compute_env = env_response["computeEnvironments"][0]
+
+            # Check if it's a Fargate environment
+            # Fargate environments have computeResources.type == "FARGATE" or "FARGATE_SPOT"
+            compute_resources = compute_env.get("computeResources", {})
+            resource_type = compute_resources.get("type", "")
+
+            if resource_type in ["FARGATE", "FARGATE_SPOT"]:
+                self.logger.info(
+                    f"Detected FARGATE platform from queue {self.settings.job_queue}"
+                )
+                return BATCH_JOB_PLATFORM_CAPABILITIES.FARGATE.value
+            else:
+                self.logger.info(
+                    f"Detected EC2 platform from queue {self.settings.job_queue}"
+                )
+                return BATCH_JOB_PLATFORM_CAPABILITIES.EC2.value
+
+        except Exception as e:
+            self.logger.warning(
+                f"Failed to determine platform from queue: {e}. Defaulting to EC2."
+            )
+            return BATCH_JOB_PLATFORM_CAPABILITIES.EC2.value
+
+    def _validate_fargate_resources(self, vcpu: int, mem: int) -> tuple[str, str]:
+        """Validates vcpu and memory conform to Fargate requirements.
+
+        Fargate requires strict memory/vCPU combinations.
+        https://docs.aws.amazon.com/batch/latest/userguide/fargate.html
+        """
         if mem in VALID_RESOURCES_MAPPING:
             if vcpu in VALID_RESOURCES_MAPPING[mem]:
                 return str(vcpu), str(mem)
             else:
-                raise WorkflowError(f"Invalid vCPU value {vcpu} for memory {mem} MB")
+                raise WorkflowError(f"Invalid vCPU value {vcpu} for memory {mem} MB on Fargate")
         else:
             min_mem = min([m for m, v in VALID_RESOURCES_MAPPING.items() if vcpu in v])
             self.logger.warning(
-                f"Memory value {mem} MB is invalid for vCPU {vcpu}."
+                f"Memory value {mem} MB is invalid for vCPU {vcpu} on Fargate. "
                 f"Setting memory to minimum allowed value {min_mem} MB."
             )
             return str(vcpu), str(min_mem)
+
+    def _validate_ec2_resources(self, vcpu: int, mem: int) -> tuple[str, str]:
+        """Validates vcpu and memory for EC2 compute environments.
+
+        EC2 allows flexible resource allocation - just basic sanity checks.
+        https://docs.aws.amazon.com/batch/latest/userguide/compute_environment_parameters.html
+        """
+        if vcpu < 1:
+            raise WorkflowError(f"vCPU must be at least 1, got {vcpu}")
+        if mem < 1024:
+            raise WorkflowError(f"Memory must be at least 1024 MiB, got {mem} MiB")
+        return str(vcpu), str(mem)
+
+    def _validate_resources(self, vcpu: str, mem: str) -> tuple[str, str]:
+        """Validates vcpu and memory based on platform requirements.
+
+        https://docs.aws.amazon.com/batch/latest/APIReference/API_ResourceRequirement.html
+        """
+        vcpu_int = int(vcpu)
+        mem_int = int(mem)
+
+        if self.platform == BATCH_JOB_PLATFORM_CAPABILITIES.FARGATE.value:
+            return self._validate_fargate_resources(vcpu_int, mem_int)
+        else:
+            return self._validate_ec2_resources(vcpu_int, mem_int)
 
     def build_job_definition(self):
         job_uuid = str(uuid.uuid4())
@@ -66,7 +157,7 @@ class BatchJobBuilder:
         # Validate and convert resources
         gpu = max(0, int(self.job.resources.get("_gpus", 0)))
         vcpu = max(1, int(self.job.resources.get("_cores", 1)))  # Default to 1 vCPU
-        mem = max(1, int(self.job.resources.get("mem_mb", 2048)))  # Default to 2048 MiB
+        mem = max(1, int(self.job.resources.get("mem_mb", 1024)))  # Default to 1024 MiB
 
         vcpu_str, mem_str = self._validate_resources(str(vcpu), str(mem))
         gpu_str = str(gpu)
@@ -111,7 +202,7 @@ class BatchJobBuilder:
                 containerProperties=container_properties,
                 timeout=timeout,
                 tags=tags,
-                platformCapabilities=[BATCH_JOB_PLATFORM_CAPABILITIES.EC2.value],
+                platformCapabilities=[self.platform],
             )
             self.created_job_defs.append(job_def)
             return job_def, job_name

--- a/snakemake_executor_plugin_aws_batch/batch_job_builder.py
+++ b/snakemake_executor_plugin_aws_batch/batch_job_builder.py
@@ -1,5 +1,7 @@
+import os
 import uuid
 from typing import Any, List
+from botocore.exceptions import ClientError
 from snakemake_interface_common.exceptions import WorkflowError
 from snakemake_interface_executor_plugins.jobs import JobExecutorInterface
 from snakemake_executor_plugin_aws_batch.batch_client import BatchClient
@@ -9,6 +11,8 @@ from snakemake_executor_plugin_aws_batch.constant import (
     BATCH_JOB_PLATFORM_CAPABILITIES,
     BATCH_JOB_RESOURCE_REQUIREMENT_TYPE,
 )
+
+SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR = "SNAKEMAKE_AWS_BATCH_JOB_TAGS"
 
 
 class BatchJobBuilder:
@@ -30,6 +34,14 @@ class BatchJobBuilder:
         self.job_command = job_command
         self.batch_client = batch_client
         self.created_job_defs = []
+        # Per-rule queue override via `resources.batch_queue` — lets a multi-arch
+        # workflow route each job to a queue wired to matching compute environment
+        # (e.g. ARM vs x86). Falls back to the profile-wide default queue.
+        self.job_queue = str(
+            self.job.resources.get("batch_queue", self.settings.job_queue)
+        )
+        # Determine platform from job queue
+        self.platform = self._get_platform_from_queue()
 
     def _make_container_command(self, remote_command: str) -> List[str]:
         """
@@ -37,36 +49,164 @@ class BatchJobBuilder:
         """
         return ["/bin/bash", "-c", remote_command]
 
-    def _validate_resources(self, vcpu: str, mem: str) -> tuple[str, str]:
-        """Validates vcpu and meme conform to Batch EC2 cpu/mem relationship
-
-        https://docs.aws.amazon.com/batch/latest/APIReference/API_ResourceRequirement.html
+    def _get_platform_from_queue(self) -> str:
         """
-        vcpu = int(vcpu)
-        mem = int(mem)
+        Determine the platform (EC2 or FARGATE) from the job queue's
+        compute environments.
 
+        :return: Platform capability string (EC2 or FARGATE)
+        """
+        try:
+            # Query the job queue
+            queue_response = self.batch_client.describe_job_queues(
+                jobQueues=[self.job_queue]
+            )
+
+            if not queue_response.get("jobQueues"):
+                self.logger.warning(
+                    f"Job queue {self.job_queue} not found. Defaulting to EC2."
+                )
+                return BATCH_JOB_PLATFORM_CAPABILITIES.EC2.value
+
+            job_queue = queue_response["jobQueues"][0]
+            compute_env_order = job_queue.get("computeEnvironmentOrder", [])
+
+            if not compute_env_order:
+                self.logger.warning(
+                    f"No compute environments found for queue {self.job_queue}. "
+                    "Defaulting to EC2."
+                )
+                return BATCH_JOB_PLATFORM_CAPABILITIES.EC2.value
+
+            # Get the first compute environment ARN
+            compute_env_arn = compute_env_order[0]["computeEnvironment"]
+
+            # Query the compute environment to get its type
+            env_response = self.batch_client.describe_compute_environments(
+                computeEnvironments=[compute_env_arn]
+            )
+
+            if not env_response.get("computeEnvironments"):
+                self.logger.warning(
+                    f"Compute environment {compute_env_arn} not found. "
+                    "Defaulting to EC2."
+                )
+                return BATCH_JOB_PLATFORM_CAPABILITIES.EC2.value
+
+            compute_env = env_response["computeEnvironments"][0]
+
+            # Check if it's a Fargate environment
+            # Fargate environments have computeResources.type ==
+            # "FARGATE" or "FARGATE_SPOT"
+            compute_resources = compute_env.get("computeResources", {})
+            resource_type = compute_resources.get("type", "")
+
+            if resource_type in ["FARGATE", "FARGATE_SPOT"]:
+                self.logger.info(
+                    f"Detected FARGATE platform from queue {self.job_queue}"
+                )
+                return BATCH_JOB_PLATFORM_CAPABILITIES.FARGATE.value
+            else:
+                self.logger.info(f"Detected EC2 platform from queue {self.job_queue}")
+                return BATCH_JOB_PLATFORM_CAPABILITIES.EC2.value
+
+        except ClientError as e:
+            # Real AWS errors (permissions, invalid queue, throttling) must
+            # surface immediately. The EC2 fallback is reserved for the
+            # explicit empty-response branches above where AWS replied
+            # successfully but the resource is missing.
+            raise WorkflowError(
+                f"Failed to determine platform from queue " f"{self.job_queue}: {e}"
+            ) from e
+
+    def _validate_fargate_resources(self, vcpu: int, mem: int) -> tuple[str, str]:
+        """Validates vcpu and memory conform to Fargate requirements.
+
+        Fargate requires strict memory/vCPU combinations.
+        https://docs.aws.amazon.com/batch/latest/userguide/fargate.html
+        """
         if mem in VALID_RESOURCES_MAPPING:
             if vcpu in VALID_RESOURCES_MAPPING[mem]:
                 return str(vcpu), str(mem)
             else:
-                raise WorkflowError(f"Invalid vCPU value {vcpu} for memory {mem} MB")
+                raise WorkflowError(
+                    f"Invalid vCPU value {vcpu} for memory {mem} MB on Fargate"
+                )
         else:
-            min_mem = min([m for m, v in VALID_RESOURCES_MAPPING.items() if vcpu in v])
+            valid_mems = [m for m, v in VALID_RESOURCES_MAPPING.items() if vcpu in v]
+            if not valid_mems:
+                raise WorkflowError(
+                    f"Invalid vCPU value {vcpu} for Fargate. "
+                    f"Check valid Fargate resource configurations."
+                )
+            # Pick the smallest valid memory that still satisfies the request.
+            # Picking min(valid_mems) unconditionally would silently shrink
+            # e.g. mem=5000 down to 2048 and OOM the job.
+            candidate_mems = [m for m in valid_mems if m >= mem]
+            if not candidate_mems:
+                raise WorkflowError(
+                    f"Memory value {mem} MB exceeds the maximum allowed for "
+                    f"vCPU {vcpu} on Fargate."
+                )
+            min_mem = min(candidate_mems)
             self.logger.warning(
-                f"Memory value {mem} MB is invalid for vCPU {vcpu}."
-                f"Setting memory to minimum allowed value {min_mem} MB."
+                f"Memory value {mem} MB is invalid for vCPU {vcpu} on Fargate. "
+                f"Setting memory to next allowed value {min_mem} MB."
             )
             return str(vcpu), str(min_mem)
 
+    def _validate_ec2_resources(self, vcpu: int, mem: int) -> tuple[str, str]:
+        """Validates vcpu and memory for EC2 compute environments.
+
+        EC2 allows flexible resource allocation - just basic sanity checks.
+        https://docs.aws.amazon.com/batch/latest/userguide/compute_environment_parameters.html
+        """
+        if vcpu < 1:
+            raise WorkflowError(f"vCPU must be at least 1, got {vcpu}")
+        if mem < 1024:
+            raise WorkflowError(f"Memory must be at least 1024 MiB, got {mem} MiB")
+        return str(vcpu), str(mem)
+
+    def _validate_resources(self, vcpu: str, mem: str) -> tuple[str, str]:
+        """Validates vcpu and memory based on platform requirements.
+
+        https://docs.aws.amazon.com/batch/latest/APIReference/API_ResourceRequirement.html
+        """
+        vcpu_int = int(vcpu)
+        mem_int = int(mem)
+
+        if self.platform == BATCH_JOB_PLATFORM_CAPABILITIES.FARGATE.value:
+            return self._validate_fargate_resources(vcpu_int, mem_int)
+        else:
+            return self._validate_ec2_resources(vcpu_int, mem_int)
+
     def build_job_definition(self):
+        # Fargate requires platform-specific container properties this plugin
+        # does not yet emit (executionRoleArn is mandatory; privileged mode
+        # and GPU resources are unsupported). Without those changes the
+        # register_job_definition call would be rejected by AWS. Fail fast
+        # here with a clear message until Fargate support is wired through.
+        if self.platform == BATCH_JOB_PLATFORM_CAPABILITIES.FARGATE.value:
+            raise WorkflowError(
+                f"Fargate job definitions are not supported by this plugin "
+                f"(queue {self.job_queue} resolves to FARGATE). "
+                f"Use an EC2-backed AWS Batch queue instead."
+            )
+
         job_uuid = str(uuid.uuid4())
         job_name = f"snakejob-{self.job.name}-{job_uuid}"
         job_definition_name = f"snakejob-def-{self.job.name}-{job_uuid}"
 
         # Validate and convert resources
         gpu = max(0, int(self.job.resources.get("_gpus", 0)))
-        vcpu = max(1, int(self.job.resources.get("_cores", 1)))  # Default to 1 vCPU
-        mem = max(1, int(self.job.resources.get("mem_mb", 2048)))  # Default to 2048 MiB
+        # Use threads directive, fall back to _cores for backward compatibility
+        vcpu = max(
+            1,
+            self.job.threads
+            if self.job.threads > 0
+            else int(self.job.resources.get("_cores", 1)),
+        )
+        mem = max(1, int(self.job.resources.get("mem_mb", 1024)))  # Default to 1024 MiB
 
         vcpu_str, mem_str = self._validate_resources(str(vcpu), str(mem))
         gpu_str = str(gpu)
@@ -102,6 +242,29 @@ class BatchJobBuilder:
                 }
             )
 
+        # Optional /dev/shm sizing. POSIX shm_open writes there; the EC2/ECS
+        # default is 64 MB which is too small for tools that stage large
+        # in-memory indexes (e.g. bwa-mem2 shm). Rules opt in via
+        # `resources.shared_memory_size_mb`. Only applies on EC2 — Fargate
+        # does not honor linuxParameters.sharedMemorySize.
+        shm_size_mb = self.job.resources.get("shared_memory_size_mb")
+        if shm_size_mb and self.platform == BATCH_JOB_PLATFORM_CAPABILITIES.EC2.value:
+            try:
+                shm_size = int(shm_size_mb)
+            except (TypeError, ValueError) as e:
+                raise WorkflowError(
+                    f"Invalid shared_memory_size_mb resource {shm_size_mb!r}: "
+                    f"must be an integer number of MiB."
+                ) from e
+            if shm_size <= 0:
+                raise WorkflowError(
+                    f"Invalid shared_memory_size_mb resource {shm_size}: "
+                    f"must be a positive number of MiB."
+                )
+            container_properties["linuxParameters"] = {
+                "sharedMemorySize": shm_size,
+            }
+
         # Only include `timeout` when task_timeout is explicitly set — omitting the
         # key means AWS Batch applies no timeout, which is the correct default for
         # long-running bioinformatics workloads. When set, enforce the AWS minimum
@@ -112,13 +275,16 @@ class BatchJobBuilder:
                 f"--aws-batch-task-timeout must be at least 60 seconds (AWS minimum), "
                 f"got {task_timeout}."
             )
-        tags = self.settings.tags if isinstance(self.settings.tags, dict) else dict()
+        # Use the same validated, env-merged tag set as submit_job so the job
+        # definition carries identical tags (each job registers its own
+        # definition, so per-run cost-tracking tags apply to both).
+        tags = self._build_job_tags()
         register_kwargs: dict[str, Any] = dict(
             jobDefinitionName=job_definition_name,
             type=BATCH_JOB_DEFINITION_TYPE.CONTAINER.value,
             containerProperties=container_properties,
             tags=tags,
-            platformCapabilities=[BATCH_JOB_PLATFORM_CAPABILITIES.EC2.value],
+            platformCapabilities=[self.platform],
         )
         if task_timeout is not None:
             register_kwargs["timeout"] = {"attemptDurationSeconds": task_timeout}
@@ -129,16 +295,72 @@ class BatchJobBuilder:
         except Exception as e:
             raise WorkflowError(f"Failed to register job definition: {e}") from e
 
+    def _build_job_tags(self) -> dict:
+        """Build the tags dict for job submission.
+
+        Merges tags from settings with those from the SNAKEMAKE_AWS_BATCH_JOB_TAGS
+        environment variable (comma-separated KEY=VALUE pairs). Environment variable
+        tags take precedence over settings tags on key conflicts.
+
+        Malformed env input is rejected with a WorkflowError: empty keys
+        (``=value``) and pairs without ``=`` (``value``). Empty pairs from
+        trailing or doubled commas are tolerated. AWS Batch caps a job at 50
+        tags; exceeding that also raises locally so the job fails fast
+        instead of at submit_job time.
+
+        :return: Merged tags dict (may be empty).
+        """
+        tags: dict = (
+            dict(self.settings.tags) if isinstance(self.settings.tags, dict) else {}
+        )
+        for key in tags:
+            if not key or not key.strip():
+                raise WorkflowError(
+                    "Invalid tags in settings: tag key cannot be empty."
+                )
+
+        env_tags_str = os.environ.get(SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR, "")
+        if env_tags_str:
+            for pair in env_tags_str.split(","):
+                pair = pair.strip()
+                if not pair:
+                    # Tolerate trailing or doubled commas.
+                    continue
+                if "=" not in pair:
+                    raise WorkflowError(
+                        f"Invalid {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR}: "
+                        f"malformed pair {pair!r} (expected KEY=VALUE)."
+                    )
+                key, _, value = pair.partition("=")
+                key = key.strip()
+                if not key:
+                    raise WorkflowError(
+                        f"Invalid {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR}: "
+                        "tag key cannot be empty."
+                    )
+                tags[key] = value.strip()
+
+        if len(tags) > 50:
+            raise WorkflowError(
+                f"AWS Batch jobs support at most 50 tags, got {len(tags)}."
+            )
+
+        return tags
+
     def submit(self):
         job_def, job_name = self.build_job_definition()
 
         job_params = {
             "jobName": job_name,
-            "jobQueue": self.settings.job_queue,
+            "jobQueue": self.job_queue,
             "jobDefinition": "{}:{}".format(
                 job_def["jobDefinitionName"], job_def["revision"]
             ),
         }
+
+        tags = self._build_job_tags()
+        if tags:
+            job_params["tags"] = tags
 
         try:
             submitted = self.batch_client.submit_job(**job_params)

--- a/snakemake_executor_plugin_aws_batch/batch_job_builder.py
+++ b/snakemake_executor_plugin_aws_batch/batch_job_builder.py
@@ -156,7 +156,8 @@ class BatchJobBuilder:
 
         # Validate and convert resources
         gpu = max(0, int(self.job.resources.get("_gpus", 0)))
-        vcpu = max(1, int(self.job.resources.get("_cores", 1)))  # Default to 1 vCPU
+        # Use threads directive, fall back to _cores for backward compatibility
+        vcpu = max(1, self.job.threads if self.job.threads > 0 else int(self.job.resources.get("_cores", 1)))
         mem = max(1, int(self.job.resources.get("mem_mb", 1024)))  # Default to 1024 MiB
 
         vcpu_str, mem_str = self._validate_resources(str(vcpu), str(mem))

--- a/snakemake_executor_plugin_aws_batch/batch_job_builder.py
+++ b/snakemake_executor_plugin_aws_batch/batch_job_builder.py
@@ -117,7 +117,13 @@ class BatchJobBuilder:
             else:
                 raise WorkflowError(f"Invalid vCPU value {vcpu} for memory {mem} MB on Fargate")
         else:
-            min_mem = min([m for m, v in VALID_RESOURCES_MAPPING.items() if vcpu in v])
+            valid_mems = [m for m, v in VALID_RESOURCES_MAPPING.items() if vcpu in v]
+            if not valid_mems:
+                raise WorkflowError(
+                    f"Invalid vCPU value {vcpu} for Fargate. "
+                    f"Check valid Fargate resource configurations."
+                )
+            min_mem = min(valid_mems)
             self.logger.warning(
                 f"Memory value {mem} MB is invalid for vCPU {vcpu} on Fargate. "
                 f"Setting memory to minimum allowed value {min_mem} MB."

--- a/snakemake_executor_plugin_aws_batch/batch_job_builder.py
+++ b/snakemake_executor_plugin_aws_batch/batch_job_builder.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 from typing import List
 from snakemake_interface_common.exceptions import WorkflowError
@@ -9,6 +10,8 @@ from snakemake_executor_plugin_aws_batch.constant import (
     BATCH_JOB_PLATFORM_CAPABILITIES,
     BATCH_JOB_RESOURCE_REQUIREMENT_TYPE,
 )
+
+SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR = "SNAKEMAKE_AWS_BATCH_JOB_TAGS"
 
 
 class BatchJobBuilder:
@@ -216,6 +219,27 @@ class BatchJobBuilder:
         except Exception as e:
             raise WorkflowError(f"Failed to register job definition: {e}") from e
 
+    def _build_job_tags(self) -> dict:
+        """Build the tags dict for job submission.
+
+        Merges tags from settings with those from the SNAKEMAKE_AWS_BATCH_JOB_TAGS
+        environment variable (comma-separated KEY=VALUE pairs). Environment variable
+        tags take precedence over settings tags on key conflicts.
+
+        :return: Merged tags dict (may be empty).
+        """
+        tags: dict = dict(self.settings.tags) if isinstance(self.settings.tags, dict) else {}
+
+        env_tags_str = os.environ.get(SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR, "")
+        if env_tags_str:
+            for pair in env_tags_str.split(","):
+                pair = pair.strip()
+                if "=" in pair:
+                    key, _, value = pair.partition("=")
+                    tags[key.strip()] = value.strip()
+
+        return tags
+
     def submit(self):
         job_def, job_name = self.build_job_definition()
 
@@ -226,6 +250,10 @@ class BatchJobBuilder:
                 job_def["jobDefinitionName"], job_def["revision"]
             ),
         }
+
+        tags = self._build_job_tags()
+        if tags:
+            job_params["tags"] = tags
 
         try:
             submitted = self.batch_client.submit_job(**job_params)

--- a/tests/test_batch_job_builder.py
+++ b/tests/test_batch_job_builder.py
@@ -1,28 +1,613 @@
-"""Tests for BatchJobBuilder — task_timeout behaviour."""
+"""Unit tests for BatchJobBuilder.
 
+Covers tag propagation, platform detection error handling, Fargate resource
+validation, and Fargate rejection in build_job_definition. All tests run with
+mocked AWS clients — no AWS credentials required.
+"""
+
+import os
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
-
+from botocore.exceptions import ClientError
 from snakemake_interface_common.exceptions import WorkflowError
-from snakemake_executor_plugin_aws_batch.batch_job_builder import BatchJobBuilder
+
+from snakemake_executor_plugin_aws_batch.batch_job_builder import (
+    SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR,
+    BatchJobBuilder,
+)
+from snakemake_executor_plugin_aws_batch.constant import (
+    BATCH_JOB_PLATFORM_CAPABILITIES,
+)
 
 
-def _fake_job_def(name="snakejob-def-test"):
-    return {
-        "jobDefinitionName": name,
-        "jobDefinitionArn": (
-            f"arn:aws:batch:us-east-1:123456789:job-definition/{name}:1"
-        ),
-        "revision": 1,
-        "status": "ACTIVE",
-        "type": "container",
-    }
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
-def _make_builder(task_timeout) -> BatchJobBuilder:
-    """Return a BatchJobBuilder with the given task_timeout setting."""
+def _make_builder(tags=None) -> BatchJobBuilder:
+    """Return a BatchJobBuilder with minimal mocks.
+
+    The batch_client is fully mocked so no AWS calls are made.  build_job_definition
+    is patched in each test that exercises submit() so we only test the tag-assembly
+    logic in isolation.
+    """
+    settings = SimpleNamespace(
+        job_queue="test-queue",
+        job_role="arn:aws:iam::123456789:role/test-role",
+        tags=tags,
+        task_timeout=300,
+    )
+
+    batch_client = MagicMock()
+    # _get_platform_from_queue is called during __init__; short-circuit it.
+    batch_client.describe_job_queues.return_value = {"jobQueues": []}
+
+    logger = MagicMock()
+    job = MagicMock()
+    job.name = "test_rule"
+    job.threads = 1
+    job.resources = {"_cores": 1, "mem_mb": 1024}
+
+    builder = BatchJobBuilder(
+        logger=logger,
+        job=job,
+        envvars={},
+        container_image="test-image:latest",
+        settings=settings,
+        job_command="snakemake ...",
+        batch_client=batch_client,
+    )
+    return builder
+
+
+def _fake_job_def():
+    """Return a minimal job-definition response for build_job_definition mocking."""
+    return {"jobDefinitionName": "snakejob-def-test", "revision": 1}
+
+
+# ---------------------------------------------------------------------------
+# Tests for _build_job_tags
+# ---------------------------------------------------------------------------
+
+
+class TestBuildJobTags:
+    def test_none_settings_tags_returns_empty(self):
+        builder = _make_builder(tags=None)
+        assert builder._build_job_tags() == {}
+
+    def test_empty_dict_settings_tags_returns_empty(self):
+        builder = _make_builder(tags={})
+        assert builder._build_job_tags() == {}
+
+    def test_settings_tags_included(self):
+        builder = _make_builder(tags={"Env": "prod", "Project": "fgumi"})
+        result = builder._build_job_tags()
+        assert result == {"Env": "prod", "Project": "fgumi"}
+
+    def test_settings_tags_not_mutated(self):
+        """_build_job_tags must return a copy, not mutate settings.tags."""
+        original = {"Env": "prod"}
+        builder = _make_builder(tags=original)
+        result = builder._build_job_tags()
+        result["Extra"] = "value"
+        assert "Extra" not in original
+
+    def test_env_var_tags_parsed_and_merged(self):
+        builder = _make_builder(tags={"Env": "prod"})
+        with patch.dict(
+            os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: "Team=data,Cost=low"}
+        ):
+            result = builder._build_job_tags()
+        assert result == {"Env": "prod", "Team": "data", "Cost": "low"}
+
+    def test_env_var_tags_override_settings_tags_on_conflict(self):
+        builder = _make_builder(tags={"Env": "prod", "Team": "bio"})
+        with patch.dict(
+            os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: "Team=data"}
+        ):
+            result = builder._build_job_tags()
+        assert result["Team"] == "data"
+        assert result["Env"] == "prod"
+
+    def test_env_var_only_no_settings_tags(self):
+        builder = _make_builder(tags=None)
+        with patch.dict(
+            os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: "Owner=alice"}
+        ):
+            result = builder._build_job_tags()
+        assert result == {"Owner": "alice"}
+
+    def test_env_var_with_value_containing_equals(self):
+        """A VALUE that itself contains '=' should be handled (key=rest of string)."""
+        builder = _make_builder(tags=None)
+        with patch.dict(
+            os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: "Url=http://x=1"}
+        ):
+            result = builder._build_job_tags()
+        assert result == {"Url": "http://x=1"}
+
+    def test_empty_env_var_ignored(self):
+        builder = _make_builder(tags={"Env": "prod"})
+        with patch.dict(os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: ""}):
+            result = builder._build_job_tags()
+        assert result == {"Env": "prod"}
+
+    def test_trailing_comma_tolerated(self):
+        builder = _make_builder(tags=None)
+        with patch.dict(
+            os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: "Env=prod,"}
+        ):
+            result = builder._build_job_tags()
+        assert result == {"Env": "prod"}
+
+    def test_doubled_comma_tolerated(self):
+        builder = _make_builder(tags=None)
+        with patch.dict(
+            os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: "Env=prod,,Team=data"}
+        ):
+            result = builder._build_job_tags()
+        assert result == {"Env": "prod", "Team": "data"}
+
+    def test_malformed_pair_without_equals_raises(self):
+        """A non-empty pair lacking '=' must raise, not silently vanish."""
+        builder = _make_builder(tags=None)
+        with patch.dict(os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: "Env prod"}):
+            with pytest.raises(WorkflowError, match="malformed pair"):
+                builder._build_job_tags()
+
+    def test_absent_env_var_ignored(self):
+        builder = _make_builder(tags={"Env": "prod"})
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k != SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR
+        }
+        with patch.dict(os.environ, env, clear=True):
+            result = builder._build_job_tags()
+        assert result == {"Env": "prod"}
+
+
+# ---------------------------------------------------------------------------
+# Tests for submit() — tags propagation to batch_client.submit_job
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitTagPropagation:
+    def _run_submit(self, builder: BatchJobBuilder):
+        """Patch build_job_definition and submit_job, then call submit()."""
+        builder.batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+            "jobQueue": "test-queue",
+        }
+        with patch.object(
+            builder,
+            "build_job_definition",
+            return_value=(_fake_job_def(), "snakejob-test"),
+        ):
+            return builder.submit(), builder.batch_client.submit_job.call_args
+
+    def test_tags_from_settings_passed_to_submit_job(self):
+        builder = _make_builder(tags={"Env": "prod"})
+        _, call_args = self._run_submit(builder)
+        assert _extract_tags(call_args) == {"Env": "prod"}
+
+    def test_env_var_tags_passed_to_submit_job(self):
+        builder = _make_builder(tags=None)
+        with patch.dict(
+            os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: "Team=data"}
+        ):
+            _, call_args = self._run_submit(builder)
+        assert _extract_tags(call_args) == {"Team": "data"}
+
+    def test_merged_tags_passed_to_submit_job(self):
+        builder = _make_builder(tags={"Env": "prod"})
+        with patch.dict(
+            os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: "Team=data"}
+        ):
+            _, call_args = self._run_submit(builder)
+        assert _extract_tags(call_args) == {"Env": "prod", "Team": "data"}
+
+    def test_no_tags_key_in_job_params_when_empty(self):
+        """When tags is empty, 'tags' should not appear in submit_job call."""
+        builder = _make_builder(tags=None)
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k != SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR
+        }
+        with patch.dict(os.environ, env, clear=True):
+            _, call_args = self._run_submit(builder)
+        assert _extract_tags(call_args) is None
+
+    def test_env_var_overrides_settings_in_submit_job(self):
+        builder = _make_builder(tags={"Team": "bio"})
+        with patch.dict(
+            os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: "Team=data"}
+        ):
+            _, call_args = self._run_submit(builder)
+        assert _extract_tags(call_args) == {"Team": "data"}
+
+    def test_default_queue_passed_to_submit_job(self):
+        builder = _make_builder(tags=None)
+        _, call_args = self._run_submit(builder)
+        assert call_args.kwargs["jobQueue"] == "test-queue"
+
+    def test_per_rule_queue_override_passed_to_submit_job(self):
+        """resources.batch_queue must route the job to the override queue."""
+        template = _make_builder(tags=None)
+        job = MagicMock()
+        job.name = "test_rule"
+        job.threads = 1
+        job.resources = {"_cores": 1, "mem_mb": 1024, "batch_queue": "override-queue"}
+        builder = BatchJobBuilder(
+            logger=MagicMock(),
+            job=job,
+            envvars={},
+            container_image="test-image:latest",
+            settings=template.settings,
+            job_command="snakemake ...",
+            batch_client=template.batch_client,
+        )
+        _, call_args = self._run_submit(builder)
+        assert call_args.kwargs["jobQueue"] == "override-queue"
+
+
+def _extract_tags(call_args) -> dict | None:
+    """Extract the 'tags' value from a mock call_args, or None if not present."""
+    # call_args is a unittest.mock.call object; kwargs is the preferred accessor
+    if call_args is None:
+        return None
+    kwargs = call_args.kwargs if hasattr(call_args, "kwargs") else call_args[1]
+    return kwargs.get("tags")
+
+
+# ---------------------------------------------------------------------------
+# Tests for _get_platform_from_queue — exception handling
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlatformFromQueue:
+    def _make_settings(self):
+        return SimpleNamespace(
+            job_queue="test-queue",
+            job_role="arn:aws:iam::123456789:role/test-role",
+            tags=None,
+            task_timeout=300,
+        )
+
+    def _make_job(self):
+        job = MagicMock()
+        job.name = "test_rule"
+        job.threads = 1
+        job.resources = {"_cores": 1, "mem_mb": 1024}
+        return job
+
+    def _build(self, batch_client):
+        return BatchJobBuilder(
+            logger=MagicMock(),
+            job=self._make_job(),
+            envvars={},
+            container_image="test-image:latest",
+            settings=self._make_settings(),
+            job_command="snakemake ...",
+            batch_client=batch_client,
+        )
+
+    def test_client_error_propagates(self):
+        """ClientError from describe_job_queues must not become an EC2 fallback."""
+        batch_client = MagicMock()
+        batch_client.describe_job_queues.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "no perm"}},
+            "DescribeJobQueues",
+        )
+        with pytest.raises(WorkflowError, match="Failed to determine platform"):
+            self._build(batch_client)
+
+    def test_unexpected_exception_propagates(self):
+        """Unexpected (non-ClientError) exceptions must propagate."""
+        batch_client = MagicMock()
+        batch_client.describe_job_queues.side_effect = RuntimeError("boom")
+        with pytest.raises(RuntimeError, match="boom"):
+            self._build(batch_client)
+
+    def test_empty_queue_response_falls_back_to_ec2(self):
+        """The explicit empty-response branch keeps the EC2 fallback."""
+        batch_client = MagicMock()
+        batch_client.describe_job_queues.return_value = {"jobQueues": []}
+        builder = self._build(batch_client)
+        assert builder.platform == BATCH_JOB_PLATFORM_CAPABILITIES.EC2.value
+
+    def test_empty_compute_environment_response_falls_back_to_ec2(self):
+        batch_client = MagicMock()
+        batch_client.describe_job_queues.return_value = {
+            "jobQueues": [
+                {"computeEnvironmentOrder": [{"computeEnvironment": "ce-arn"}]}
+            ]
+        }
+        batch_client.describe_compute_environments.return_value = {
+            "computeEnvironments": []
+        }
+        builder = self._build(batch_client)
+        assert builder.platform == BATCH_JOB_PLATFORM_CAPABILITIES.EC2.value
+
+    def test_fargate_compute_environment_detected(self):
+        batch_client = MagicMock()
+        batch_client.describe_job_queues.return_value = {
+            "jobQueues": [
+                {"computeEnvironmentOrder": [{"computeEnvironment": "ce-arn"}]}
+            ]
+        }
+        batch_client.describe_compute_environments.return_value = {
+            "computeEnvironments": [{"computeResources": {"type": "FARGATE"}}]
+        }
+        builder = self._build(batch_client)
+        assert builder.platform == BATCH_JOB_PLATFORM_CAPABILITIES.FARGATE.value
+
+
+# ---------------------------------------------------------------------------
+# Tests for _validate_fargate_resources — memory >= requested
+# ---------------------------------------------------------------------------
+
+
+class TestValidateFargateResources:
+    def test_picks_smallest_valid_mem_geq_requested(self):
+        """vcpu=1, mem=5000 must pick 5120 (smallest valid >= 5000), not 2048."""
+        builder = _make_builder(tags=None)
+        builder.platform = BATCH_JOB_PLATFORM_CAPABILITIES.FARGATE.value
+        vcpu_str, mem_str = builder._validate_resources("1", "5000")
+        assert vcpu_str == "1"
+        assert mem_str == "5120"
+
+    def test_picks_exact_mem_when_in_mapping(self):
+        builder = _make_builder(tags=None)
+        builder.platform = BATCH_JOB_PLATFORM_CAPABILITIES.FARGATE.value
+        vcpu_str, mem_str = builder._validate_resources("1", "4096")
+        assert (vcpu_str, mem_str) == ("1", "4096")
+
+    def test_raises_when_request_exceeds_max_for_vcpu(self):
+        """vcpu=1 maxes at 8192 MB; requesting 99999 must raise, not shrink."""
+        builder = _make_builder(tags=None)
+        builder.platform = BATCH_JOB_PLATFORM_CAPABILITIES.FARGATE.value
+        with pytest.raises(WorkflowError, match="exceeds the maximum"):
+            builder._validate_resources("1", "99999")
+
+    def test_raises_for_invalid_vcpu(self):
+        builder = _make_builder(tags=None)
+        builder.platform = BATCH_JOB_PLATFORM_CAPABILITIES.FARGATE.value
+        with pytest.raises(WorkflowError, match="Invalid vCPU"):
+            builder._validate_resources("3", "4096")
+
+
+# ---------------------------------------------------------------------------
+# Tests for build_job_definition — tags parity with submit_job
+# ---------------------------------------------------------------------------
+
+
+class TestJobDefinitionTags:
+    def test_job_definition_tags_match_submit_tags(self):
+        """register_job_definition must get the same validated, env-merged tags."""
+        builder = _make_builder(tags={"Env": "prod"})
+        builder.batch_client.register_job_definition.return_value = _fake_job_def()
+        with patch.dict(
+            os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: "Team=data"}
+        ):
+            builder.build_job_definition()
+        call_kwargs = builder.batch_client.register_job_definition.call_args.kwargs
+        assert call_kwargs["tags"] == {"Env": "prod", "Team": "data"}
+
+
+# ---------------------------------------------------------------------------
+# Tests for _validate_ec2_resources
+# ---------------------------------------------------------------------------
+
+
+class TestValidateEc2Resources:
+    def test_valid_resources_pass_through(self):
+        builder = _make_builder(tags=None)
+        assert builder._validate_resources("4", "5000") == ("4", "5000")
+
+    def test_vcpu_below_one_raises(self):
+        builder = _make_builder(tags=None)
+        with pytest.raises(WorkflowError, match="vCPU must be at least 1"):
+            builder._validate_ec2_resources(0, 2048)
+
+    def test_mem_below_1024_raises(self):
+        builder = _make_builder(tags=None)
+        with pytest.raises(WorkflowError, match="Memory must be at least 1024"):
+            builder._validate_ec2_resources(1, 512)
+
+
+# ---------------------------------------------------------------------------
+# Tests for _build_job_tags — validation
+# ---------------------------------------------------------------------------
+
+
+class TestBuildJobTagsValidation:
+    def test_empty_key_in_env_var_raises(self):
+        builder = _make_builder(tags=None)
+        with patch.dict(os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: "=value"}):
+            with pytest.raises(WorkflowError, match="tag key cannot be empty"):
+                builder._build_job_tags()
+
+    def test_empty_key_after_strip_in_env_var_raises(self):
+        builder = _make_builder(tags=None)
+        with patch.dict(
+            os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: "   =value"}
+        ):
+            with pytest.raises(WorkflowError, match="tag key cannot be empty"):
+                builder._build_job_tags()
+
+    def test_empty_key_in_settings_tags_raises(self):
+        builder = _make_builder(tags={"": "value"})
+        with pytest.raises(WorkflowError, match="tag key cannot be empty"):
+            builder._build_job_tags()
+
+    def test_too_many_tags_raises(self):
+        too_many = {f"k{i}": str(i) for i in range(51)}
+        builder = _make_builder(tags=too_many)
+        with pytest.raises(WorkflowError, match="at most 50 tags"):
+            builder._build_job_tags()
+
+    def test_exactly_50_tags_ok(self):
+        fifty = {f"k{i}": str(i) for i in range(50)}
+        builder = _make_builder(tags=fifty)
+        result = builder._build_job_tags()
+        assert len(result) == 50
+
+
+# ---------------------------------------------------------------------------
+# Tests for error messages — resolved per-job queue
+# ---------------------------------------------------------------------------
+
+
+class TestErrorMessagesUseResolvedQueue:
+    """Diagnostics must show the resolved per-job queue (resources.batch_queue
+    override), not the profile-wide default from settings."""
+
+    def _make_job_with_queue_override(self):
+        job = MagicMock()
+        job.name = "test_rule"
+        job.threads = 1
+        job.resources = {"_cores": 1, "mem_mb": 1024, "batch_queue": "override-queue"}
+        return job
+
+    def _make_settings(self):
+        return SimpleNamespace(
+            job_queue="default-queue",
+            job_role="arn:aws:iam::123456789:role/test-role",
+            tags=None,
+            task_timeout=300,
+        )
+
+    def test_platform_detection_error_reports_resolved_queue(self):
+        """ClientError diagnostics must name the per-job override queue."""
+        batch_client = MagicMock()
+        batch_client.describe_job_queues.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "no perm"}},
+            "DescribeJobQueues",
+        )
+        with pytest.raises(WorkflowError, match="override-queue"):
+            BatchJobBuilder(
+                logger=MagicMock(),
+                job=self._make_job_with_queue_override(),
+                envvars={},
+                container_image="test-image:latest",
+                settings=self._make_settings(),
+                job_command="snakemake ...",
+                batch_client=batch_client,
+            )
+
+    def test_fargate_rejection_reports_resolved_queue(self):
+        """The Fargate fail-fast message must name the per-job override queue."""
+        batch_client = MagicMock()
+        batch_client.describe_job_queues.return_value = {"jobQueues": []}
+        builder = BatchJobBuilder(
+            logger=MagicMock(),
+            job=self._make_job_with_queue_override(),
+            envvars={},
+            container_image="test-image:latest",
+            settings=self._make_settings(),
+            job_command="snakemake ...",
+            batch_client=batch_client,
+        )
+        builder.platform = BATCH_JOB_PLATFORM_CAPABILITIES.FARGATE.value
+        with pytest.raises(WorkflowError, match="override-queue"):
+            builder.build_job_definition()
+
+
+# ---------------------------------------------------------------------------
+# Tests for build_job_definition — shared_memory_size_mb
+# ---------------------------------------------------------------------------
+
+
+class TestSharedMemorySize:
+    def _build_with_shm(self, shm_value):
+        builder = _make_builder(tags=None)
+        builder.job.resources = dict(
+            builder.job.resources, shared_memory_size_mb=shm_value
+        )
+        builder.batch_client.register_job_definition.return_value = _fake_job_def()
+        return builder
+
+    def test_shm_size_sets_linux_parameters(self):
+        builder = self._build_with_shm(4096)
+        builder.build_job_definition()
+        props = builder.batch_client.register_job_definition.call_args.kwargs[
+            "containerProperties"
+        ]
+        assert props["linuxParameters"] == {"sharedMemorySize": 4096}
+
+    def test_shm_size_accepts_string_values(self):
+        """Snakemake resources may arrive as strings; ints must still come out."""
+        builder = self._build_with_shm("2048")
+        builder.build_job_definition()
+        props = builder.batch_client.register_job_definition.call_args.kwargs[
+            "containerProperties"
+        ]
+        assert props["linuxParameters"] == {"sharedMemorySize": 2048}
+
+    def test_unset_shm_size_omits_linux_parameters(self):
+        builder = _make_builder(tags=None)
+        builder.batch_client.register_job_definition.return_value = _fake_job_def()
+        builder.build_job_definition()
+        props = builder.batch_client.register_job_definition.call_args.kwargs[
+            "containerProperties"
+        ]
+        assert "linuxParameters" not in props
+
+    def test_non_numeric_shm_size_raises_workflow_error(self):
+        builder = self._build_with_shm("4g")
+        with pytest.raises(WorkflowError, match="shared_memory_size_mb"):
+            builder.build_job_definition()
+
+    def test_negative_shm_size_raises_workflow_error(self):
+        builder = self._build_with_shm(-64)
+        with pytest.raises(WorkflowError, match="positive"):
+            builder.build_job_definition()
+
+
+# ---------------------------------------------------------------------------
+# Tests for build_job_definition — Fargate rejection
+# ---------------------------------------------------------------------------
+
+
+class TestBuildJobDefinitionFargateRejection:
+    def test_fargate_platform_raises_workflow_error(self):
+        """build_job_definition must reject Fargate until properties are wired."""
+        builder = _make_builder(tags=None)
+        builder.platform = BATCH_JOB_PLATFORM_CAPABILITIES.FARGATE.value
+        with pytest.raises(WorkflowError, match="Fargate"):
+            builder.build_job_definition()
+        # No registration should have been attempted.
+        builder.batch_client.register_job_definition.assert_not_called()
+
+    def test_ec2_platform_does_not_raise(self):
+        builder = _make_builder(tags=None)
+        # _make_builder leaves platform == EC2 (empty queue response branch).
+        assert builder.platform == BATCH_JOB_PLATFORM_CAPABILITIES.EC2.value
+        builder.batch_client.register_job_definition.return_value = {
+            "jobDefinitionName": "snakejob-def-test",
+            "revision": 1,
+        }
+        job_def, job_name = builder.build_job_definition()
+        assert job_def["jobDefinitionName"] == "snakejob-def-test"
+        assert job_name.startswith("snakejob-test_rule-")
+
+
+# ---------------------------------------------------------------------------
+# Tests for task_timeout behaviour (conditional timeout, AWS 60s minimum)
+# ---------------------------------------------------------------------------
+
+
+def _make_timeout_builder(task_timeout) -> BatchJobBuilder:
+    """Return a BatchJobBuilder with the given task_timeout.
+
+    Mocks short-circuit platform detection to EC2 (empty queue response).
+    """
     settings = SimpleNamespace(
         job_queue="test-queue",
         job_role="arn:aws:iam::123456789:role/test-role",
@@ -30,10 +615,12 @@ def _make_builder(task_timeout) -> BatchJobBuilder:
         task_timeout=task_timeout,
     )
     batch_client = MagicMock()
+    batch_client.describe_job_queues.return_value = {"jobQueues": []}
     batch_client.register_job_definition.return_value = _fake_job_def()
 
     job = MagicMock()
     job.name = "test_rule"
+    job.threads = 1
     job.resources = {"_cores": 1, "mem_mb": 1024}
 
     return BatchJobBuilder(
@@ -50,49 +637,49 @@ def _make_builder(task_timeout) -> BatchJobBuilder:
 class TestTaskTimeout:
     def test_default_none_omits_timeout_from_register_kwargs(self):
         """None task_timeout: register_job_definition must not receive a timeout key."""
-        builder = _make_builder(None)
+        builder = _make_timeout_builder(None)
         builder.build_job_definition()
         call_kwargs = builder.batch_client.register_job_definition.call_args.kwargs
         assert "timeout" not in call_kwargs
 
     def test_set_timeout_includes_timeout_in_register_kwargs(self):
         """Set task_timeout: register_job_definition must receive the timeout dict."""
-        builder = _make_builder(3600)
+        builder = _make_timeout_builder(3600)
         builder.build_job_definition()
         call_kwargs = builder.batch_client.register_job_definition.call_args.kwargs
         assert call_kwargs["timeout"] == {"attemptDurationSeconds": 3600}
 
     def test_minimum_valid_timeout_60_passes(self):
         """60 seconds is the AWS minimum; it must not raise."""
-        builder = _make_builder(60)
+        builder = _make_timeout_builder(60)
         builder.build_job_definition()
         call_kwargs = builder.batch_client.register_job_definition.call_args.kwargs
         assert call_kwargs["timeout"] == {"attemptDurationSeconds": 60}
 
     def test_timeout_below_60_raises_workflow_error(self):
         """task_timeout < 60 must raise WorkflowError before calling the API."""
-        builder = _make_builder(59)
+        builder = _make_timeout_builder(59)
         with pytest.raises(WorkflowError, match="60"):
             builder.build_job_definition()
         builder.batch_client.register_job_definition.assert_not_called()
 
     def test_timeout_of_1_raises_workflow_error(self):
         """Any value below 60 must be rejected."""
-        builder = _make_builder(1)
+        builder = _make_timeout_builder(1)
         with pytest.raises(WorkflowError, match="60"):
             builder.build_job_definition()
         builder.batch_client.register_job_definition.assert_not_called()
 
     def test_timeout_of_0_raises_workflow_error(self):
         """Zero is below the AWS minimum; must raise WorkflowError."""
-        builder = _make_builder(0)
+        builder = _make_timeout_builder(0)
         with pytest.raises(WorkflowError, match="60"):
             builder.build_job_definition()
         builder.batch_client.register_job_definition.assert_not_called()
 
     def test_timeout_negative_raises_workflow_error(self):
         """Negative values are below the AWS minimum; must raise WorkflowError."""
-        builder = _make_builder(-1)
+        builder = _make_timeout_builder(-1)
         with pytest.raises(WorkflowError, match="60"):
             builder.build_job_definition()
         builder.batch_client.register_job_definition.assert_not_called()

--- a/tests/test_batch_job_builder.py
+++ b/tests/test_batch_job_builder.py
@@ -1,0 +1,189 @@
+"""Unit tests for BatchJobBuilder.submit() tag handling.
+
+These tests focus solely on tag propagation to submit_job and do not require
+AWS credentials or a live Snakemake workflow.
+"""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from snakemake_executor_plugin_aws_batch.batch_job_builder import (
+    SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR,
+    BatchJobBuilder,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_builder(tags=None) -> BatchJobBuilder:
+    """Return a BatchJobBuilder with minimal mocks.
+
+    The batch_client is fully mocked so no AWS calls are made.  build_job_definition
+    is patched in each test that exercises submit() so we only test the tag-assembly
+    logic in isolation.
+    """
+    settings = SimpleNamespace(
+        job_queue="test-queue",
+        job_role="arn:aws:iam::123456789:role/test-role",
+        tags=tags,
+        task_timeout=300,
+    )
+
+    batch_client = MagicMock()
+    # _get_platform_from_queue is called during __init__; short-circuit it.
+    batch_client.describe_job_queues.return_value = {"jobQueues": []}
+
+    logger = MagicMock()
+    job = MagicMock()
+    job.name = "test_rule"
+    job.threads = 1
+    job.resources = {"_cores": 1, "mem_mb": 1024}
+
+    builder = BatchJobBuilder(
+        logger=logger,
+        job=job,
+        envvars={},
+        container_image="test-image:latest",
+        settings=settings,
+        job_command="snakemake ...",
+        batch_client=batch_client,
+    )
+    return builder
+
+
+def _fake_job_def():
+    """Return a minimal job-definition response for build_job_definition mocking."""
+    return {"jobDefinitionName": "snakejob-def-test", "revision": 1}
+
+
+# ---------------------------------------------------------------------------
+# Tests for _build_job_tags
+# ---------------------------------------------------------------------------
+
+class TestBuildJobTags:
+    def test_none_settings_tags_returns_empty(self):
+        builder = _make_builder(tags=None)
+        assert builder._build_job_tags() == {}
+
+    def test_empty_dict_settings_tags_returns_empty(self):
+        builder = _make_builder(tags={})
+        assert builder._build_job_tags() == {}
+
+    def test_settings_tags_included(self):
+        builder = _make_builder(tags={"Env": "prod", "Project": "fgumi"})
+        result = builder._build_job_tags()
+        assert result == {"Env": "prod", "Project": "fgumi"}
+
+    def test_settings_tags_not_mutated(self):
+        """_build_job_tags must return a copy, not mutate settings.tags."""
+        original = {"Env": "prod"}
+        builder = _make_builder(tags=original)
+        result = builder._build_job_tags()
+        result["Extra"] = "value"
+        assert "Extra" not in original
+
+    def test_env_var_tags_parsed_and_merged(self):
+        builder = _make_builder(tags={"Env": "prod"})
+        with patch.dict(os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: "Team=data,Cost=low"}):
+            result = builder._build_job_tags()
+        assert result == {"Env": "prod", "Team": "data", "Cost": "low"}
+
+    def test_env_var_tags_override_settings_tags_on_conflict(self):
+        builder = _make_builder(tags={"Env": "prod", "Team": "bio"})
+        with patch.dict(os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: "Team=data"}):
+            result = builder._build_job_tags()
+        assert result["Team"] == "data"
+        assert result["Env"] == "prod"
+
+    def test_env_var_only_no_settings_tags(self):
+        builder = _make_builder(tags=None)
+        with patch.dict(os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: "Owner=alice"}):
+            result = builder._build_job_tags()
+        assert result == {"Owner": "alice"}
+
+    def test_env_var_with_value_containing_equals(self):
+        """A VALUE that itself contains '=' should be handled (key=rest of string)."""
+        builder = _make_builder(tags=None)
+        with patch.dict(os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: "Url=http://x=1"}):
+            result = builder._build_job_tags()
+        assert result == {"Url": "http://x=1"}
+
+    def test_empty_env_var_ignored(self):
+        builder = _make_builder(tags={"Env": "prod"})
+        with patch.dict(os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: ""}):
+            result = builder._build_job_tags()
+        assert result == {"Env": "prod"}
+
+    def test_absent_env_var_ignored(self):
+        builder = _make_builder(tags={"Env": "prod"})
+        env = {k: v for k, v in os.environ.items() if k != SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR}
+        with patch.dict(os.environ, env, clear=True):
+            result = builder._build_job_tags()
+        assert result == {"Env": "prod"}
+
+
+# ---------------------------------------------------------------------------
+# Tests for submit() — tags propagation to batch_client.submit_job
+# ---------------------------------------------------------------------------
+
+class TestSubmitTagPropagation:
+    def _run_submit(self, builder: BatchJobBuilder):
+        """Patch build_job_definition and submit_job, then call submit()."""
+        builder.batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+            "jobQueue": "test-queue",
+        }
+        with patch.object(builder, "build_job_definition", return_value=(_fake_job_def(), "snakejob-test")):
+            return builder.submit(), builder.batch_client.submit_job.call_args
+
+    def test_tags_from_settings_passed_to_submit_job(self):
+        builder = _make_builder(tags={"Env": "prod"})
+        _, call_args = self._run_submit(builder)
+        assert call_args.kwargs.get("tags") == {"Env": "prod"} or \
+               call_args[1].get("tags") == {"Env": "prod"} or \
+               ("tags" in call_args[0][0] if call_args[0] else False) or \
+               call_args.kwargs.get("tags") == {"Env": "prod"}
+        # Normalise: extract the tags kwarg regardless of how mock recorded it
+        submitted_tags = _extract_tags(call_args)
+        assert submitted_tags == {"Env": "prod"}
+
+    def test_env_var_tags_passed_to_submit_job(self):
+        builder = _make_builder(tags=None)
+        with patch.dict(os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: "Team=data"}):
+            _, call_args = self._run_submit(builder)
+        assert _extract_tags(call_args) == {"Team": "data"}
+
+    def test_merged_tags_passed_to_submit_job(self):
+        builder = _make_builder(tags={"Env": "prod"})
+        with patch.dict(os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: "Team=data"}):
+            _, call_args = self._run_submit(builder)
+        assert _extract_tags(call_args) == {"Env": "prod", "Team": "data"}
+
+    def test_no_tags_key_in_job_params_when_empty(self):
+        """When tags is empty, 'tags' should not appear in submit_job call."""
+        builder = _make_builder(tags=None)
+        env = {k: v for k, v in os.environ.items() if k != SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR}
+        with patch.dict(os.environ, env, clear=True):
+            _, call_args = self._run_submit(builder)
+        assert _extract_tags(call_args) is None
+
+    def test_env_var_overrides_settings_in_submit_job(self):
+        builder = _make_builder(tags={"Team": "bio"})
+        with patch.dict(os.environ, {SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR: "Team=data"}):
+            _, call_args = self._run_submit(builder)
+        assert _extract_tags(call_args) == {"Team": "data"}
+
+
+def _extract_tags(call_args) -> dict | None:
+    """Extract the 'tags' value from a mock call_args, or None if not present."""
+    # call_args is a unittest.mock.call object; kwargs is the preferred accessor
+    if call_args is None:
+        return None
+    kwargs = call_args.kwargs if hasattr(call_args, "kwargs") else call_args[1]
+    return kwargs.get("tags")

--- a/tests/tests_mocked_api.py
+++ b/tests/tests_mocked_api.py
@@ -6,6 +6,15 @@ class TestWorkflowsMocked(TestWorkflowsBase):
     __test__ = True
 
     @patch(
+        # BatchJobBuilder.__init__ calls _get_platform_from_queue(), which issues
+        # live describe_job_queues / describe_compute_environments calls. Without
+        # AWS credentials (as in CI) these raise NoCredentialsError before submit
+        # is ever reached, so short-circuit platform detection to EC2.
+        "snakemake_executor_plugin_aws_batch.batch_job_builder."
+        "BatchJobBuilder._get_platform_from_queue",
+        return_value="EC2",
+    )
+    @patch(
         "snakemake_executor_plugin_aws_batch.batch_job_builder.BatchJobBuilder.submit",
         return_value={"jobName": "job_id", "jobId": "job_id", "jobQueue": "job_queue"},
     )


### PR DESCRIPTION
## Summary

Hardens the AWS Batch executor for multi-arch, multi-tenant production use. Three user-facing capabilities plus underlying validation/compat fixes.

### What's new

- **Per-rule queue routing** via `resources.batch_queue` — route each rule to a Batch queue wired to the matching compute environment. Enables a single workflow to run ARM rules on Graviton queues and x86 rules on Intel/AMD queues. Falls back to the profile default queue.
- **Per-job tags** — `settings.tags` are now sent to `submit_job` (not only `register_job_definition`), so the AWS Batch console and Cost Explorer can group jobs by tag. A `SNAKEMAKE_AWS_BATCH_JOB_TAGS` env var carries dynamic `KEY=VALUE` pairs for coordinator → worker tag inheritance (e.g. per-run commit hashes for cost attribution). Env tags override settings on key conflict.
- **`resources.shared_memory_size_mb`** — rules opt into a larger `/dev/shm` (EC2/ECS default 64 MB is too small for tools that stage large in-memory indexes). EC2 only; Fargate does not honor `linuxParameters.sharedMemorySize`.

### Validation and correctness

- **EC2 vs FARGATE detection** (closes #34): resolves the queue's compute environment and runs platform-specific vCPU/memory checks. Previously all jobs were validated against Fargate's strict resource matrix, which blocked legitimate EC2 requests. Real AWS lookup errors (`botocore.ClientError`) now propagate as `WorkflowError` instead of silently falling back to EC2.
- **vCPU from `threads`** — derived from `self.job.threads` (the documented Snakemake directive) instead of the undocumented `_cores` resource, with `_cores` retained as fallback.
- **Fargate memory floor** — when the requested memory is not a valid Fargate value, pick the smallest valid memory `>= mem` instead of silently shrinking to `min(valid_mems)` and OOMing the job. Raise if no valid value exists.
- **Tag validation** — reject empty tag keys and >50 tags before calling `submit_job`, matching AWS Batch limits.

### Known limitation

Fargate job-definition registration is not yet supported. Fargate requires `executionRoleArn`, prohibits `privileged: True`, and does not allow GPU resources — none of which this plugin currently emits conditionally. `build_job_definition` raises a clear `WorkflowError` when a Fargate queue is detected, replacing an opaque AWS-side rejection with a local message. EC2 queues are unaffected.

### Compatibility

- `auto_deploy_default_storage_provider=False` so workers don't `pip install` an unpinned `snakemake-storage-plugin-s3` at startup — s3-plugin 0.3.x metadata requires snakemake 9.x and breaks 8.x workers. Image maintainers pre-install a compatible plugin version.
- `snakemake-storage-plugin-s3` pin widened to `>=0.2,<0.4` so 8.x consumers can fall back to 0.2.x.

## Dependencies

Stacked on #38 (`fix-vcpu-threads-and-validation`) — the first three commits here are the same as #38's, so #38 should land first (or be closed in favor of this PR).

## Test plan

- [x] 31 unit tests in `tests/test_batch_job_builder.py`:
  - Tag assembly + propagation to `submit_job` (settings, env var, merge, override, empty cases)
  - Tag validation (empty keys from env or settings, 50-tag boundary)
  - Platform detection (`ClientError` re-raises, empty-response fallback, Fargate detection)
  - Fargate resource validation (smallest valid ≥ requested, exact match, request exceeds maximum, invalid vCPU)
  - Fargate rejection in `build_job_definition`
- [x] All existing tests still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queue-aware job submission with per-job queue override, Fargate support, and job tagging with env-var overrides.

* **Behavior Changes**
  * Platform-aware resource validation, vCPU/memory default adjustments (mem default 1024 MiB), EC2-only shared-memory support, and submission uses resolved job queue.
  * Disabled automatic default storage provider deployment.

* **Documentation**
  * Expanded AWS Batch executor guidance, tagging, queue overrides, and shared-memory notes.

* **Tests**
  * Comprehensive unit tests for builder, tagging, platform detection, resources, and timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->