### PR TITLE
fix: don't apply a 300s default task timeout to every job

### DIFF
--- a/.github/workflows/ci_mocked_api.yml
+++ b/.github/workflows/ci_mocked_api.yml
@@ -102,7 +102,7 @@ jobs:
         env:
           SNAKEMAKE_AWS_BATCH_JOB_QUEUE: "${{ secrets.SNAKEMAKE_AWS_BATCH_JOB_QUEUE }}"
           SNAKEMAKE_AWS_BATCH_JOB_ROLE: "${{ secrets.SNAKEMAKE_AWS_BATCH_JOB_ROLE }}"
-        run: poetry run coverage run -m pytest tests/tests_mocked_api.py -v
+        run: poetry run coverage run -m pytest tests/tests_mocked_api.py tests/test_batch_job_builder.py -v
 
       - name: Run Coverage
         run: poetry run coverage report -m

--- a/snakemake_executor_plugin_aws_batch/__init__.py
+++ b/snakemake_executor_plugin_aws_batch/__init__.py
@@ -64,12 +64,15 @@ class ExecutorSettings(ExecutorSettingsBase):
         },
     )
     task_timeout: Optional[int] = field(
-        default=300,
+        default=None,
         metadata={
             "help": (
-                "Task timeout (seconds) will force AWS Batch to terminate "
-                "a Batch task if it fails to finish within the timeout, minimum 60"
-            )
+                "Task timeout in seconds: AWS Batch terminates a job that does not "
+                "finish within this limit. Jobs have no timeout unless this is set. "
+                "When set, the value must be at least 60 (the AWS minimum)."
+            ),
+            "env_var": False,
+            "required": False,
         },
     )
 

--- a/snakemake_executor_plugin_aws_batch/batch_job_builder.py
+++ b/snakemake_executor_plugin_aws_batch/batch_job_builder.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import List
+from typing import Any, List
 from snakemake_interface_common.exceptions import WorkflowError
 from snakemake_interface_executor_plugins.jobs import JobExecutorInterface
 from snakemake_executor_plugin_aws_batch.batch_client import BatchClient
@@ -102,17 +102,28 @@ class BatchJobBuilder:
                 }
             )
 
-        timeout = {"attemptDurationSeconds": self.settings.task_timeout}
-        tags = self.settings.tags if isinstance(self.settings.tags, dict) else dict()
-        try:
-            job_def = self.batch_client.register_job_definition(
-                jobDefinitionName=job_definition_name,
-                type=BATCH_JOB_DEFINITION_TYPE.CONTAINER.value,
-                containerProperties=container_properties,
-                timeout=timeout,
-                tags=tags,
-                platformCapabilities=[BATCH_JOB_PLATFORM_CAPABILITIES.EC2.value],
+        # Only include `timeout` when task_timeout is explicitly set — omitting the
+        # key means AWS Batch applies no timeout, which is the correct default for
+        # long-running bioinformatics workloads. When set, enforce the AWS minimum
+        # of 60 s locally so the error is clear rather than a Batch API rejection.
+        task_timeout = self.settings.task_timeout
+        if task_timeout is not None and task_timeout < 60:
+            raise WorkflowError(
+                f"--aws-batch-task-timeout must be at least 60 seconds (AWS minimum), "
+                f"got {task_timeout}."
             )
+        tags = self.settings.tags if isinstance(self.settings.tags, dict) else dict()
+        register_kwargs: dict[str, Any] = dict(
+            jobDefinitionName=job_definition_name,
+            type=BATCH_JOB_DEFINITION_TYPE.CONTAINER.value,
+            containerProperties=container_properties,
+            tags=tags,
+            platformCapabilities=[BATCH_JOB_PLATFORM_CAPABILITIES.EC2.value],
+        )
+        if task_timeout is not None:
+            register_kwargs["timeout"] = {"attemptDurationSeconds": task_timeout}
+        try:
+            job_def = self.batch_client.register_job_definition(**register_kwargs)
             self.created_job_defs.append(job_def)
             return job_def, job_name
         except Exception as e:

--- a/tests/test_batch_job_builder.py
+++ b/tests/test_batch_job_builder.py
@@ -1,0 +1,98 @@
+"""Tests for BatchJobBuilder — task_timeout behaviour."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from snakemake_interface_common.exceptions import WorkflowError
+from snakemake_executor_plugin_aws_batch.batch_job_builder import BatchJobBuilder
+
+
+def _fake_job_def(name="snakejob-def-test"):
+    return {
+        "jobDefinitionName": name,
+        "jobDefinitionArn": (
+            f"arn:aws:batch:us-east-1:123456789:job-definition/{name}:1"
+        ),
+        "revision": 1,
+        "status": "ACTIVE",
+        "type": "container",
+    }
+
+
+def _make_builder(task_timeout) -> BatchJobBuilder:
+    """Return a BatchJobBuilder with the given task_timeout setting."""
+    settings = SimpleNamespace(
+        job_queue="test-queue",
+        job_role="arn:aws:iam::123456789:role/test-role",
+        tags=None,
+        task_timeout=task_timeout,
+    )
+    batch_client = MagicMock()
+    batch_client.register_job_definition.return_value = _fake_job_def()
+
+    job = MagicMock()
+    job.name = "test_rule"
+    job.resources = {"_cores": 1, "mem_mb": 1024}
+
+    return BatchJobBuilder(
+        logger=MagicMock(),
+        job=job,
+        envvars={},
+        container_image="test-image:latest",
+        settings=settings,
+        job_command="snakemake ...",
+        batch_client=batch_client,
+    )
+
+
+class TestTaskTimeout:
+    def test_default_none_omits_timeout_from_register_kwargs(self):
+        """None task_timeout: register_job_definition must not receive a timeout key."""
+        builder = _make_builder(None)
+        builder.build_job_definition()
+        call_kwargs = builder.batch_client.register_job_definition.call_args.kwargs
+        assert "timeout" not in call_kwargs
+
+    def test_set_timeout_includes_timeout_in_register_kwargs(self):
+        """Set task_timeout: register_job_definition must receive the timeout dict."""
+        builder = _make_builder(3600)
+        builder.build_job_definition()
+        call_kwargs = builder.batch_client.register_job_definition.call_args.kwargs
+        assert call_kwargs["timeout"] == {"attemptDurationSeconds": 3600}
+
+    def test_minimum_valid_timeout_60_passes(self):
+        """60 seconds is the AWS minimum; it must not raise."""
+        builder = _make_builder(60)
+        builder.build_job_definition()
+        call_kwargs = builder.batch_client.register_job_definition.call_args.kwargs
+        assert call_kwargs["timeout"] == {"attemptDurationSeconds": 60}
+
+    def test_timeout_below_60_raises_workflow_error(self):
+        """task_timeout < 60 must raise WorkflowError before calling the API."""
+        builder = _make_builder(59)
+        with pytest.raises(WorkflowError, match="60"):
+            builder.build_job_definition()
+        builder.batch_client.register_job_definition.assert_not_called()
+
+    def test_timeout_of_1_raises_workflow_error(self):
+        """Any value below 60 must be rejected."""
+        builder = _make_builder(1)
+        with pytest.raises(WorkflowError, match="60"):
+            builder.build_job_definition()
+        builder.batch_client.register_job_definition.assert_not_called()
+
+    def test_timeout_of_0_raises_workflow_error(self):
+        """Zero is below the AWS minimum; must raise WorkflowError."""
+        builder = _make_builder(0)
+        with pytest.raises(WorkflowError, match="60"):
+            builder.build_job_definition()
+        builder.batch_client.register_job_definition.assert_not_called()
+
+    def test_timeout_negative_raises_workflow_error(self):
+        """Negative values are below the AWS minimum; must raise WorkflowError."""
+        builder = _make_builder(-1)
+        with pytest.raises(WorkflowError, match="60"):
+            builder.build_job_definition()
+        builder.batch_client.register_job_definition.assert_not_called()


### PR DESCRIPTION
`task_timeout` defaults to 300 and is applied unconditionally in `build_job_definition`, so by default every Batch job is killed at 5 minutes — and `Optional[int]` is a lie, since "no timeout" is inexpressible. Typical bioinformatics jobs run hours; the default behavior is a workflow that mysteriously fails partway with terminated jobs.

This changes the default to `None`, omits the `timeout` kwarg from `register_job_definition` when unset (AWS then applies no timeout), and validates the AWS minimum of 60s locally with a clear `WorkflowError` (naming `--aws-batch-task-timeout`) instead of a Batch API rejection. Help text updated.

Tests (new `tests/test_batch_job_builder.py`, added to the mocked-API CI job): default omits the key; set includes it; exactly 60 passes; 59, 1, 0, and -1 raise pre-API with `register_job_definition` never called.

**Coordination note:** this overlaps with my open #40, which also creates `tests/test_batch_job_builder.py` and edits the same CI line. Suggested order: land this small fix first; #40 then rebases on top (I'll handle the rebase, folding the test files together).

Follow-up planned: a per-rule `aws_batch_task_timeout` resource, kept separate for review granularity.

---
*This PR was prepared with the assistance of coding agents; all changes were human-reviewed before submission.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validation for task timeout with AWS minimum of 60 seconds

* **Bug Fixes**
  * Task timeout now defaults to None and is conditionally applied

* **Tests**
  * Added comprehensive batch job builder test suite

* **Chores**
  * Updated CI pipeline to run additional batch job builder tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->