### PR TITLE
feat: per-rule task timeout via aws_batch_task_timeout resource

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -93,6 +93,24 @@ rule align:
 
 Platform detection and job submission both use the resolved per-rule queue.
 
+# Task Timeout
+
+By default jobs have no timeout. Set `--aws-batch-task-timeout` to impose a
+workflow-wide limit (in seconds; minimum 60). A rule can override this with the
+`aws_batch_task_timeout` resource, e.g. to give a long-running alignment step
+more time while keeping a tight limit on bookkeeping rules:
+
+```python
+rule align:
+    resources:
+        aws_batch_task_timeout=14400  # 4 h
+    ...
+```
+
+The per-rule resource takes precedence over `--aws-batch-task-timeout`. When
+neither is set, AWS Batch imposes no timeout. When set, the value must be at
+least 60 seconds (the AWS minimum).
+
 # Shared Memory (`/dev/shm`)
 
 On EC2/ECS containers `/dev/shm` defaults to 64 MB, which is too small for

--- a/snakemake_executor_plugin_aws_batch/batch_job_builder.py
+++ b/snakemake_executor_plugin_aws_batch/batch_job_builder.py
@@ -265,16 +265,32 @@ class BatchJobBuilder:
                 "sharedMemorySize": shm_size,
             }
 
-        # Only include `timeout` when task_timeout is explicitly set — omitting the
+        # Only include `timeout` when a timeout is explicitly set — omitting the
         # key means AWS Batch applies no timeout, which is the correct default for
-        # long-running bioinformatics workloads. When set, enforce the AWS minimum
-        # of 60 s locally so the error is clear rather than a Batch API rejection.
-        task_timeout = self.settings.task_timeout
-        if task_timeout is not None and task_timeout < 60:
-            raise WorkflowError(
-                f"--aws-batch-task-timeout must be at least 60 seconds (AWS minimum), "
-                f"got {task_timeout}."
-            )
+        # long-running bioinformatics workloads. The per-rule aws_batch_task_timeout
+        # resource takes precedence over the workflow-level task_timeout setting.
+        # When set, enforce the AWS minimum of 60 s locally so the error is clear
+        # rather than a Batch API rejection.
+        rule_timeout = self.job.resources.get("aws_batch_task_timeout")
+        if rule_timeout is not None:
+            task_timeout = rule_timeout
+            timeout_source = "aws_batch_task_timeout resource"
+        else:
+            task_timeout = self.settings.task_timeout
+            timeout_source = "--aws-batch-task-timeout"
+        if task_timeout is not None:
+            try:
+                task_timeout = int(task_timeout)
+            except (TypeError, ValueError) as e:
+                raise WorkflowError(
+                    f"Invalid {timeout_source} value {task_timeout!r}: "
+                    "must be an integer number of seconds (minimum 60)."
+                ) from e
+            if task_timeout < 60:
+                raise WorkflowError(
+                    f"{timeout_source} must be at least 60 seconds (AWS minimum), "
+                    f"got {task_timeout}."
+                )
         # Use the same validated, env-merged tag set as submit_job so the job
         # definition carries identical tags (each job registers its own
         # definition, so per-run cost-tracking tags apply to both).

--- a/tests/test_batch_job_builder.py
+++ b/tests/test_batch_job_builder.py
@@ -683,3 +683,112 @@ class TestTaskTimeout:
         with pytest.raises(WorkflowError, match="60"):
             builder.build_job_definition()
         builder.batch_client.register_job_definition.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests for build_job_definition — per-rule aws_batch_task_timeout resource
+# ---------------------------------------------------------------------------
+
+
+def _make_builder_with_rule_timeout(
+    setting_timeout=None, resource_timeout=None
+) -> BatchJobBuilder:
+    """Return a BatchJobBuilder for per-rule timeout tests.
+
+    setting_timeout  — value for settings.task_timeout (None = no global timeout).
+    resource_timeout — value for job.resources["aws_batch_task_timeout"]
+                       (None = key absent from resources dict).
+    """
+    resources: dict = {"_cores": 1, "mem_mb": 1024}
+    if resource_timeout is not None:
+        resources["aws_batch_task_timeout"] = resource_timeout
+
+    settings = SimpleNamespace(
+        job_queue="test-queue",
+        job_role="arn:aws:iam::123456789:role/test-role",
+        tags=None,
+        task_timeout=setting_timeout,
+    )
+    batch_client = MagicMock()
+    batch_client.describe_job_queues.return_value = {"jobQueues": []}
+    batch_client.register_job_definition.return_value = _fake_job_def()
+
+    job = MagicMock()
+    job.name = "test_rule"
+    job.threads = 1
+    job.resources = resources
+
+    return BatchJobBuilder(
+        logger=MagicMock(),
+        job=job,
+        envvars={},
+        container_image="test-image:latest",
+        settings=settings,
+        job_command="snakemake ...",
+        batch_client=batch_client,
+    )
+
+
+class TestPerRuleTaskTimeout:
+    def test_resource_overrides_setting(self):
+        """aws_batch_task_timeout resource takes precedence over the global setting."""
+        builder = _make_builder_with_rule_timeout(
+            setting_timeout=300, resource_timeout=14400
+        )
+        builder.build_job_definition()
+        call_kwargs = builder.batch_client.register_job_definition.call_args.kwargs
+        assert call_kwargs["timeout"] == {"attemptDurationSeconds": 14400}
+
+    def test_resource_alone_no_setting(self):
+        """Per-rule resource works when settings.task_timeout is None."""
+        builder = _make_builder_with_rule_timeout(
+            setting_timeout=None, resource_timeout=7200
+        )
+        builder.build_job_definition()
+        call_kwargs = builder.batch_client.register_job_definition.call_args.kwargs
+        assert call_kwargs["timeout"] == {"attemptDurationSeconds": 7200}
+
+    def test_fallback_to_setting_when_resource_absent(self):
+        """When resource is absent, the global setting is used."""
+        builder = _make_builder_with_rule_timeout(
+            setting_timeout=3600, resource_timeout=None
+        )
+        builder.build_job_definition()
+        call_kwargs = builder.batch_client.register_job_definition.call_args.kwargs
+        assert call_kwargs["timeout"] == {"attemptDurationSeconds": 3600}
+
+    def test_both_absent_omits_timeout(self):
+        """When neither resource nor setting is set, timeout is omitted."""
+        builder = _make_builder_with_rule_timeout(
+            setting_timeout=None, resource_timeout=None
+        )
+        builder.build_job_definition()
+        call_kwargs = builder.batch_client.register_job_definition.call_args.kwargs
+        assert "timeout" not in call_kwargs
+
+    def test_resource_below_60_raises_workflow_error(self):
+        """Per-rule timeout < 60 must raise WorkflowError."""
+        builder = _make_builder_with_rule_timeout(
+            setting_timeout=None, resource_timeout=30
+        )
+        with pytest.raises(WorkflowError, match="60"):
+            builder.build_job_definition()
+        builder.batch_client.register_job_definition.assert_not_called()
+
+    def test_non_numeric_resource_raises_workflow_error(self):
+        """Non-numeric aws_batch_task_timeout (e.g. '4h') must raise WorkflowError."""
+        builder = _make_builder_with_rule_timeout(
+            setting_timeout=None, resource_timeout="4h"
+        )
+        with pytest.raises(WorkflowError, match="aws_batch_task_timeout"):
+            builder.build_job_definition()
+        builder.batch_client.register_job_definition.assert_not_called()
+
+    def test_resource_exactly_60_passes(self):
+        """Exactly 60 seconds via resource is the AWS minimum and must not raise."""
+        builder = _make_builder_with_rule_timeout(
+            setting_timeout=None, resource_timeout=60
+        )
+        builder.build_job_definition()
+        call_kwargs = builder.batch_client.register_job_definition.call_args.kwargs
+        assert call_kwargs["timeout"] == {"attemptDurationSeconds": 60}


### PR DESCRIPTION
Adds a per-rule `aws_batch_task_timeout` resource that overrides the workflow-level `--aws-batch-task-timeout` setting, mirroring the existing per-rule `batch_queue` pattern.

- **Precedence:** the per-rule resource wins over the global flag; falls back to the flag when the resource is absent; omits the timeout entirely when neither is set (preserving the no-default-timeout behavior from #41).
- **Validation:** the value is coerced to an integer and must be ≥ 60 s (the AWS minimum). Errors name the source (resource vs flag) so the cause is unambiguous.

```python
rule align:
    resources:
        aws_batch_task_timeout=14400  # 4 h
    ...
```

Depends on #41 (conditional task-timeout), now merged. Documented under a new "Task Timeout" section in `docs/further.md`.

### Testing
New `TestPerRuleTaskTimeout` covers precedence, resource-only, fallback, both-absent, `< 60`, non-numeric, and the exact-60 boundary. Full suite: 61 unit tests pass; black + flake8 clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Support for per-rule AWS Batch task timeout configuration, which takes precedence over workflow-level settings.
  * Workflow-level timeout control with minimum 60-second validation (AWS requirement); omitted if not configured.

* **Documentation**
  * Added "Task Timeout" section with configuration examples and behavior clarification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->