### PR TITLE
feat: job scheduling priority via setting and per-rule resource

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -77,6 +77,36 @@ therefore pre-install a compatible version of the storage plugin (e.g.
 are responsible for pinning a plugin version compatible with the snakemake
 version in the image.
 
+# Scheduling Priority (Fair-Share Queues)
+
+AWS Batch fair-share job queues (those with a scheduling policy attached) order
+jobs by priority at submit time via `schedulingPriorityOverride`. The plugin
+exposes this at two levels, both optional:
+
+- `--aws-batch-scheduling-priority` — a workflow-level default applied to every
+  submitted job.
+- `aws_batch_scheduling_priority` resource — a per-rule override that takes
+  precedence over the workflow-level setting.
+
+Both are ignored by AWS on non-fair-share queues. When neither is set the
+`schedulingPriorityOverride` parameter is omitted entirely from the submit call,
+keeping submissions byte-identical to the pre-feature behavior.
+
+Workflow-level default (all jobs):
+
+```sh
+snakemake --executor aws-batch --aws-batch-scheduling-priority 50 ...
+```
+
+Per-rule override (e.g. boost the critical path above background jobs):
+
+```python
+rule critical_path:
+    resources:
+        aws_batch_scheduling_priority=100
+    ...
+```
+
 # Per-Rule Job Queues
 
 By default all jobs are submitted to the queue given by

--- a/snakemake_executor_plugin_aws_batch/__init__.py
+++ b/snakemake_executor_plugin_aws_batch/__init__.py
@@ -75,6 +75,20 @@ class ExecutorSettings(ExecutorSettingsBase):
             "required": False,
         },
     )
+    scheduling_priority: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Default scheduling priority applied to every submitted job "
+                "(schedulingPriorityOverride). Only meaningful on fair-share job "
+                "queues, i.e. queues with a scheduling policy attached; ignored "
+                "otherwise. Per-rule overrides via the "
+                "aws_batch_scheduling_priority resource take precedence."
+            ),
+            "env_var": False,
+            "required": False,
+        },
+    )
 
 
 # Required:

--- a/snakemake_executor_plugin_aws_batch/batch_job_builder.py
+++ b/snakemake_executor_plugin_aws_batch/batch_job_builder.py
@@ -378,6 +378,36 @@ class BatchJobBuilder:
         if tags:
             job_params["tags"] = tags
 
+        # Per-rule scheduling priority override for fair-share queues. The
+        # aws_batch_scheduling_priority resource takes precedence over the
+        # workflow-level scheduling_priority setting. When neither is set the
+        # kwarg is omitted entirely so submissions are byte-identical to today
+        # on non-fair-share queues.
+        resource_priority = self.job.resources.get("aws_batch_scheduling_priority")
+        setting_priority = getattr(self.settings, "scheduling_priority", None)
+        if resource_priority is not None:
+            priority = resource_priority
+            priority_source = "aws_batch_scheduling_priority resource"
+        elif setting_priority is not None:
+            priority = setting_priority
+            priority_source = "--aws-batch-scheduling-priority setting"
+        else:
+            priority = None
+            priority_source = ""
+        if priority is not None:
+            try:
+                priority_int = int(priority)
+            except (TypeError, ValueError) as e:
+                raise WorkflowError(
+                    f"Invalid {priority_source} {priority!r}: must be an integer."
+                ) from e
+            if not (0 <= priority_int <= 9999):
+                raise WorkflowError(
+                    f"Invalid {priority_source} {priority_int}: "
+                    "must be in range [0, 9999]."
+                )
+            job_params["schedulingPriorityOverride"] = priority_int
+
         try:
             submitted = self.batch_client.submit_job(**job_params)
             return submitted

--- a/tests/test_batch_job_builder.py
+++ b/tests/test_batch_job_builder.py
@@ -792,3 +792,188 @@ class TestPerRuleTaskTimeout:
         builder.build_job_definition()
         call_kwargs = builder.batch_client.register_job_definition.call_args.kwargs
         assert call_kwargs["timeout"] == {"attemptDurationSeconds": 60}
+
+
+# ---------------------------------------------------------------------------
+# Tests for submit() — scheduling priority
+# ---------------------------------------------------------------------------
+
+
+def _make_builder_with_priority(setting_priority=None, resource_priority=None):
+    """Return a BatchJobBuilder configured for scheduling-priority tests.
+
+    setting_priority  — value for settings.scheduling_priority (None = unset).
+    resource_priority — value for job.resources["aws_batch_scheduling_priority"]
+                        (None = key absent from resources dict).
+    """
+    resources = {"_cores": 1, "mem_mb": 1024}
+    if resource_priority is not None:
+        resources["aws_batch_scheduling_priority"] = resource_priority
+
+    settings = SimpleNamespace(
+        job_queue="test-queue",
+        job_role="arn:aws:iam::123456789:role/test-role",
+        tags=None,
+        scheduling_priority=setting_priority,
+    )
+
+    batch_client = MagicMock()
+    batch_client.describe_job_queues.return_value = {"jobQueues": []}
+
+    job = MagicMock()
+    job.name = "test_rule"
+    job.threads = 1
+    job.resources = resources
+
+    return BatchJobBuilder(
+        logger=MagicMock(),
+        job=job,
+        envvars={},
+        container_image="test-image:latest",
+        settings=settings,
+        job_command="snakemake ...",
+        batch_client=batch_client,
+    )
+
+
+def _run_submit_priority(builder):
+    """Patch build_job_definition and call submit(); return submit_job call_args."""
+    builder.batch_client.submit_job.return_value = {
+        "jobName": "snakejob-test",
+        "jobId": "abc-123",
+        "jobQueue": "test-queue",
+    }
+    with patch.object(
+        builder,
+        "build_job_definition",
+        return_value=(_fake_job_def(), "snakejob-test"),
+    ):
+        builder.submit()
+    return builder.batch_client.submit_job.call_args
+
+
+class TestSubmitSchedulingPriority:
+    def test_unset_omits_kwarg(self):
+        """When neither setting nor resource is set, schedulingPriorityOverride
+        must be absent from the submit_job call."""
+        builder = _make_builder_with_priority(
+            setting_priority=None, resource_priority=None
+        )
+        call_args = _run_submit_priority(builder)
+        assert "schedulingPriorityOverride" not in call_args.kwargs
+
+    def test_setting_only_present_with_value(self):
+        """A workflow-level setting is forwarded when no per-rule override exists."""
+        builder = _make_builder_with_priority(
+            setting_priority=50, resource_priority=None
+        )
+        call_args = _run_submit_priority(builder)
+        assert call_args.kwargs["schedulingPriorityOverride"] == 50
+
+    def test_resource_overrides_setting(self):
+        """Per-rule aws_batch_scheduling_priority takes precedence over the setting."""
+        builder = _make_builder_with_priority(
+            setting_priority=10, resource_priority=100
+        )
+        call_args = _run_submit_priority(builder)
+        assert call_args.kwargs["schedulingPriorityOverride"] == 100
+
+    def test_resource_alone_works(self):
+        """Per-rule resource without any workflow-level setting is applied."""
+        builder = _make_builder_with_priority(
+            setting_priority=None, resource_priority=75
+        )
+        call_args = _run_submit_priority(builder)
+        assert call_args.kwargs["schedulingPriorityOverride"] == 75
+
+    def test_non_numeric_resource_raises_workflow_error(self):
+        """A non-numeric aws_batch_scheduling_priority resource raises WorkflowError
+        and does not call submit_job."""
+        builder = _make_builder_with_priority(
+            setting_priority=None, resource_priority="high"
+        )
+        with patch.object(
+            builder,
+            "build_job_definition",
+            return_value=(_fake_job_def(), "snakejob-test"),
+        ):
+            with pytest.raises(WorkflowError, match="aws_batch_scheduling_priority"):
+                builder.submit()
+        builder.batch_client.submit_job.assert_not_called()
+
+    def test_zero_priority_is_forwarded(self):
+        """Priority of 0 is a valid fair-share value and must be included in the call
+        (regression pin against a future ``if priority:`` refactor)."""
+        builder = _make_builder_with_priority(
+            setting_priority=None, resource_priority=0
+        )
+        call_args = _run_submit_priority(builder)
+        assert call_args.kwargs["schedulingPriorityOverride"] == 0
+
+    def test_non_numeric_setting_raises_workflow_error(self):
+        """A non-numeric --aws-batch-scheduling-priority setting raises WorkflowError
+        and does not call submit_job.  Error message must mention the setting, not
+        the resource, because the bad value came from the CLI flag."""
+        builder = _make_builder_with_priority(
+            setting_priority="high", resource_priority=None
+        )
+        with patch.object(
+            builder,
+            "build_job_definition",
+            return_value=(_fake_job_def(), "snakejob-test"),
+        ):
+            with pytest.raises(WorkflowError, match="--aws-batch-scheduling-priority"):
+                builder.submit()
+        builder.batch_client.submit_job.assert_not_called()
+
+    def test_out_of_range_resource_raises_workflow_error(self):
+        """A priority outside the AWS Batch [0, 9999] range raises WorkflowError
+        before calling submit_job."""
+        builder = _make_builder_with_priority(
+            setting_priority=None, resource_priority=10000
+        )
+        with patch.object(
+            builder,
+            "build_job_definition",
+            return_value=(_fake_job_def(), "snakejob-test"),
+        ):
+            with pytest.raises(WorkflowError, match="range"):
+                builder.submit()
+        builder.batch_client.submit_job.assert_not_called()
+
+    def test_out_of_range_setting_raises_workflow_error(self):
+        """A workflow-level scheduling priority outside [0, 9999] raises WorkflowError."""  # noqa: E501
+        builder = _make_builder_with_priority(
+            setting_priority=10000, resource_priority=None
+        )
+        with patch.object(
+            builder,
+            "build_job_definition",
+            return_value=(_fake_job_def(), "snakejob-test"),
+        ):
+            with pytest.raises(WorkflowError, match="range"):
+                builder.submit()
+        builder.batch_client.submit_job.assert_not_called()
+
+    def test_negative_priority_raises_workflow_error(self):
+        """A negative priority is below the AWS Batch minimum (0) and must raise
+        WorkflowError before calling submit_job (lower-bound regression pin)."""
+        builder = _make_builder_with_priority(
+            setting_priority=None, resource_priority=-1
+        )
+        with patch.object(
+            builder,
+            "build_job_definition",
+            return_value=(_fake_job_def(), "snakejob-test"),
+        ):
+            with pytest.raises(WorkflowError, match="range"):
+                builder.submit()
+        builder.batch_client.submit_job.assert_not_called()
+
+    def test_max_valid_priority_is_forwarded(self):
+        """Priority of 9999 (AWS maximum) must be accepted and forwarded."""
+        builder = _make_builder_with_priority(
+            setting_priority=None, resource_priority=9999
+        )
+        call_args = _run_submit_priority(builder)
+        assert call_args.kwargs["schedulingPriorityOverride"] == 9999


### PR DESCRIPTION
Adds optional AWS Batch fair-share scheduling priority support at two levels, mapped to `submit_job`'s `schedulingPriorityOverride`:

- **`--aws-batch-scheduling-priority`** — a workflow-level default applied to every job.
- **`aws_batch_scheduling_priority`** resource — a per-rule override that takes precedence over the setting (mirrors the `batch_queue` / `aws_batch_task_timeout` per-rule pattern).

The value is coerced to an integer and validated to the AWS Batch `[0, 9999]` range, with errors naming the source (resource vs setting). When neither is set, `schedulingPriorityOverride` is **omitted entirely** — submissions on non-fair-share queues are byte-identical to before. Only meaningful on fair-share queues (those with a scheduling policy attached); AWS ignores it otherwise.

```sh
snakemake --executor aws-batch --aws-batch-scheduling-priority 50 ...
```
```python
rule critical_path:
    resources:
        aws_batch_scheduling_priority=100
    ...
```

Documented under a new "Scheduling Priority (Fair-Share Queues)" section in `docs/further.md`.

### Testing
New `TestSubmitSchedulingPriority` covers unset-omits-kwarg, setting-only, resource-overrides-setting, resource-alone, non-numeric (resource + setting), out-of-range (resource + setting), negative (lower bound), and the `0` and `9999` boundaries. Full suite: 72 unit tests pass; black + flake8 clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AWS Batch fair-share queue scheduling priority support with configurable workflow-level and per-rule settings, with per-rule priorities taking precedence.

* **Documentation**
  * Added comprehensive guide for scheduling priority configuration with usage examples and details on feature behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->