### PR TITLE
feat: support pre-existing job definitions via containerOverrides

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -199,3 +199,54 @@ coordinator job can set the variable so that all child jobs it submits
 inherit the run-specific tags. AWS Batch allows at most 50 tags per job;
 malformed pairs (missing `=` or an empty key) raise an error at submission
 time.
+
+# Pre-existing Job Definitions
+
+By default the plugin registers a fresh AWS Batch job definition for every job
+and deregisters it afterward.  Accounts where job definitions are managed by
+infrastructure tooling (Terraform, CloudFormation) can opt out of this with
+`--aws-batch-job-definition`.  When set, the plugin skips
+`RegisterJobDefinition`/`DeregisterJobDefinition` entirely and instead submits
+with the supplied definition, pushing per-job specifics (command, environment
+variables, vcpu/mem/gpu) through `containerOverrides`.
+
+```bash
+snakemake --executor aws-batch \
+    --aws-batch-job-definition my-snakemake-def:3 \
+    ...
+```
+
+The value can be a bare name (`my-def`), a name:revision pair (`my-def:3`),
+or a full ARN
+(`arn:aws:batch:us-east-1:123456789012:job-definition/my-def:3`).
+
+A rule can override the setting for a specific job with the
+`aws_batch_job_definition` resource (mirrors the `batch_queue` pattern):
+
+```python
+rule align:
+    resources:
+        aws_batch_job_definition="gpu-enabled-def:2"
+    ...
+```
+
+**Incompatible combinations** — the following raise a `WorkflowError` at
+submission time because they are only meaningful when the plugin builds the
+definition:
+
+- `--aws-batch-job-role` (`job_role`): the job role is baked into the
+  definition at registration time and cannot be overridden via
+  `containerOverrides`.
+- The per-rule `shared_memory_size_mb` resource: `linuxParameters.sharedMemorySize`
+  is a definition-level field.
+
+The `--aws-batch-container-image` (`container_image`) setting and the per-rule
+`aws_batch_container_image` resource are both silently ignored in this mode — the
+container image is taken from the pre-existing definition.
+
+Task timeout and scheduling priority **are** still honored: `--aws-batch-task-timeout`
+(and the per-rule `aws_batch_task_timeout` resource) and the scheduling priority
+(`--aws-batch-scheduling-priority` / the per-rule `aws_batch_scheduling_priority`
+resource) travel as `SubmitJob`'s top-level `timeout` and `schedulingPriorityOverride`
+fields, so they apply to pre-existing definitions just as they do to dynamically
+registered ones.

--- a/snakemake_executor_plugin_aws_batch/__init__.py
+++ b/snakemake_executor_plugin_aws_batch/__init__.py
@@ -89,6 +89,23 @@ class ExecutorSettings(ExecutorSettingsBase):
             "required": False,
         },
     )
+    job_definition: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Use a pre-existing AWS Batch job definition instead of registering "
+                "one per job. Accepts a definition name (e.g. my-def), a name:revision "
+                "pair (my-def:3), or a full ARN. When set, resource configuration "
+                "(container image, job role, shared memory) is managed externally — "
+                "the container_image setting is ignored. Per-job specifics (command, "
+                "environment variables, vcpu/mem/gpu) are passed via "
+                "containerOverrides. Cannot be combined with --aws-batch-job-role "
+                "or the per-rule shared_memory_size_mb resource."
+            ),
+            "env_var": False,
+            "required": False,
+        },
+    )
 
 
 # Required:
@@ -277,6 +294,15 @@ class Executor(RemoteExecutor):
     def _deregister_job(self, job: SubmittedJobInfo):
         """deregister batch job definition"""
         try:
+            # Pre-existing job definitions are not owned by this executor;
+            # deregistering them would break other workflows using the same definition.
+            if job.aux.get("_preexisting_job_definition"):
+                self.logger.debug(
+                    "skipping deregistration of pre-existing Batch job definition "
+                    f"{job.aux.get('job_definition_arn')} "
+                    "(externally managed, not owned by this executor)"
+                )
+                return
             job_def_arn = job.aux.get("job_definition_arn")
             if job_def_arn is not None:
                 self.logger.debug(f"de-registering Batch job definition {job_def_arn}")

--- a/snakemake_executor_plugin_aws_batch/batch_job_builder.py
+++ b/snakemake_executor_plugin_aws_batch/batch_job_builder.py
@@ -1,6 +1,6 @@
 import os
 import uuid
-from typing import Any, List
+from typing import Any, List, Optional
 from botocore.exceptions import ClientError
 from snakemake_interface_common.exceptions import WorkflowError
 from snakemake_interface_executor_plugins.jobs import JobExecutorInterface
@@ -40,8 +40,27 @@ class BatchJobBuilder:
         self.job_queue = str(
             self.job.resources.get("batch_queue", self.settings.job_queue)
         )
-        # Determine platform from job queue
-        self.platform = self._get_platform_from_queue()
+        # Platform (EC2/FARGATE) is resolved lazily on first access. Pre-existing
+        # job definitions skip definition-building entirely, so they must not be
+        # forced to hold batch:DescribeJobQueues / DescribeComputeEnvironments
+        # permissions (the whole point of static definitions is a smaller IAM
+        # surface). Only the dynamic registration path touches `self.platform`.
+        self._platform: Optional[str] = None
+
+    @property
+    def platform(self) -> str:
+        """The queue's platform capability (EC2/FARGATE), resolved on first use.
+
+        Cached after the first lookup. Setting the attribute directly (e.g. in
+        tests) bypasses the queue query.
+        """
+        if self._platform is None:
+            self._platform = self._get_platform_from_queue()
+        return self._platform
+
+    @platform.setter
+    def platform(self, value: str) -> None:
+        self._platform = value
 
     def _make_container_command(self, remote_command: str) -> List[str]:
         """
@@ -267,30 +286,8 @@ class BatchJobBuilder:
 
         # Only include `timeout` when a timeout is explicitly set — omitting the
         # key means AWS Batch applies no timeout, which is the correct default for
-        # long-running bioinformatics workloads. The per-rule aws_batch_task_timeout
-        # resource takes precedence over the workflow-level task_timeout setting.
-        # When set, enforce the AWS minimum of 60 s locally so the error is clear
-        # rather than a Batch API rejection.
-        rule_timeout = self.job.resources.get("aws_batch_task_timeout")
-        if rule_timeout is not None:
-            task_timeout = rule_timeout
-            timeout_source = "aws_batch_task_timeout resource"
-        else:
-            task_timeout = self.settings.task_timeout
-            timeout_source = "--aws-batch-task-timeout"
-        if task_timeout is not None:
-            try:
-                task_timeout = int(task_timeout)
-            except (TypeError, ValueError) as e:
-                raise WorkflowError(
-                    f"Invalid {timeout_source} value {task_timeout!r}: "
-                    "must be an integer number of seconds (minimum 60)."
-                ) from e
-            if task_timeout < 60:
-                raise WorkflowError(
-                    f"{timeout_source} must be at least 60 seconds (AWS minimum), "
-                    f"got {task_timeout}."
-                )
+        # long-running bioinformatics workloads.
+        task_timeout = self._resolve_task_timeout()
         # Use the same validated, env-merged tag set as submit_job so the job
         # definition carries identical tags (each job registers its own
         # definition, so per-run cost-tracking tags apply to both).
@@ -363,7 +360,209 @@ class BatchJobBuilder:
 
         return tags
 
+    def _resolve_task_timeout(self) -> Optional[int]:
+        """Resolve the effective task timeout in seconds, or ``None``.
+
+        The per-rule ``aws_batch_task_timeout`` resource takes precedence over
+        the workflow-level ``task_timeout`` setting. Returns ``None`` when neither
+        is set so the ``timeout`` field can be omitted entirely (AWS Batch then
+        applies no timeout). Enforces the AWS minimum of 60 s locally so the error
+        is clear rather than a Batch API rejection. Raises ``WorkflowError`` for
+        non-integer or sub-minimum values.
+        """
+        rule_timeout = self.job.resources.get("aws_batch_task_timeout")
+        if rule_timeout is not None:
+            task_timeout = rule_timeout
+            timeout_source = "aws_batch_task_timeout resource"
+        else:
+            task_timeout = getattr(self.settings, "task_timeout", None)
+            timeout_source = "--aws-batch-task-timeout"
+        if task_timeout is None:
+            return None
+        try:
+            task_timeout = int(task_timeout)
+        except (TypeError, ValueError) as e:
+            raise WorkflowError(
+                f"Invalid {timeout_source} value {task_timeout!r}: "
+                "must be an integer number of seconds (minimum 60)."
+            ) from e
+        if task_timeout < 60:
+            raise WorkflowError(
+                f"{timeout_source} must be at least 60 seconds (AWS minimum), "
+                f"got {task_timeout}."
+            )
+        return task_timeout
+
+    def _resolve_scheduling_priority(self) -> Optional[int]:
+        """Resolve the effective scheduling priority override, or ``None``.
+
+        For fair-share queues. The per-rule ``aws_batch_scheduling_priority``
+        resource takes precedence over the workflow-level ``scheduling_priority``
+        setting. Returns ``None`` when neither is set so the
+        ``schedulingPriorityOverride`` kwarg can be omitted entirely — keeping
+        submissions byte-identical on non-fair-share queues. Raises
+        ``WorkflowError`` for non-integer or out-of-range values.
+        """
+        resource_priority = self.job.resources.get("aws_batch_scheduling_priority")
+        setting_priority = getattr(self.settings, "scheduling_priority", None)
+        if resource_priority is not None:
+            priority = resource_priority
+            priority_source = "aws_batch_scheduling_priority resource"
+        elif setting_priority is not None:
+            priority = setting_priority
+            priority_source = "--aws-batch-scheduling-priority setting"
+        else:
+            return None
+        try:
+            priority_int = int(priority)
+        except (TypeError, ValueError) as e:
+            raise WorkflowError(
+                f"Invalid {priority_source} {priority!r}: must be an integer."
+            ) from e
+        if not (0 <= priority_int <= 9999):
+            raise WorkflowError(
+                f"Invalid {priority_source} {priority_int}: "
+                "must be in range [0, 9999]."
+            )
+        return priority_int
+
+    def _resolve_preexisting_job_definition(self) -> Optional[str]:
+        """Return the effective pre-existing job definition name/ARN, or None.
+
+        Checks the per-rule ``aws_batch_job_definition`` resource first (mirrors
+        the ``batch_queue`` override pattern), then falls back to the
+        ``job_definition`` executor setting.  Returns ``None`` when neither is
+        set, which triggers the dynamic registration path.
+        """
+        per_rule = self.job.resources.get("aws_batch_job_definition")
+        if per_rule:
+            return str(per_rule)
+        return getattr(self.settings, "job_definition", None) or None
+
+    def _validate_preexisting_compatibility(self) -> None:
+        """Fail fast when settings that only make sense for dynamic definitions are set.
+
+        ``job_role`` is baked into the job definition at registration time and
+        cannot be overridden via ``containerOverrides``.  ``shared_memory_size_mb``
+        maps to ``linuxParameters.sharedMemorySize`` on the definition, not a
+        container override.  Both are silently useless in pre-existing mode, so we
+        raise early rather than silently ignore.
+
+        ``container_image`` cannot be distinguished from its default value so we
+        document in the setting help text that it is ignored and do not raise here.
+        """
+        if getattr(self.settings, "job_role", None):
+            raise WorkflowError(
+                "Cannot combine job_role (--aws-batch-job-role) with job_definition "
+                "(--aws-batch-job-definition): the job role is managed externally when "
+                "using a pre-existing job definition.  Remove --aws-batch-job-role or "
+                "omit --aws-batch-job-definition."
+            )
+        if self.job.resources.get("shared_memory_size_mb") is not None:
+            raise WorkflowError(
+                "Cannot combine the shared_memory_size_mb resource with "
+                "--aws-batch-job-definition: shared memory sizing is managed "
+                "externally when using a pre-existing job definition.  Remove the "
+                "shared_memory_size_mb resource or omit --aws-batch-job-definition."
+            )
+
+    def _submit_with_preexisting_definition(self, job_definition: str) -> dict:
+        """Submit a job using a pre-existing definition via containerOverrides.
+
+        Skips ``register_job_definition`` entirely.  Per-job specifics — command,
+        environment variables, vcpu/mem, and (when > 0) GPU — are passed through
+        ``containerOverrides`` so the definition's other settings remain in force.
+
+        Fargate/vcpu-mem constraint validation is intentionally skipped here:
+        the user-owned job definition already encodes the platform requirements,
+        and enforcing them here would duplicate logic that AWS validates at
+        submit time.
+
+        Returns the ``submit_job`` response dict with an extra
+        ``_preexisting_job_definition`` marker so ``_deregister_job`` knows to
+        skip deregistration.
+        """
+        self._validate_preexisting_compatibility()
+
+        job_uuid = str(uuid.uuid4())
+        job_name = f"snakejob-{self.job.name}-{job_uuid}"
+
+        gpu = max(0, int(self.job.resources.get("_gpus", 0)))
+        vcpu = max(
+            1,
+            (
+                self.job.threads
+                if self.job.threads > 0
+                else int(self.job.resources.get("_cores", 1))
+            ),
+        )
+        mem = max(1, int(self.job.resources.get("mem_mb", 1024)))
+
+        resource_requirements = [
+            {
+                "type": BATCH_JOB_RESOURCE_REQUIREMENT_TYPE.VCPU.value,
+                "value": str(vcpu),
+            },
+            {
+                "type": BATCH_JOB_RESOURCE_REQUIREMENT_TYPE.MEMORY.value,
+                "value": str(mem),
+            },
+        ]
+        if gpu > 0:
+            resource_requirements.append(
+                {
+                    "type": BATCH_JOB_RESOURCE_REQUIREMENT_TYPE.GPU.value,
+                    "value": str(gpu),
+                }
+            )
+
+        container_overrides: dict = {
+            "command": self._make_container_command(self.job_command),
+            "resourceRequirements": resource_requirements,
+        }
+        if self.envvars:
+            container_overrides["environment"] = [
+                {"name": k, "value": v} for k, v in self.envvars.items()
+            ]
+
+        job_params: dict = {
+            "jobName": job_name,
+            "jobQueue": self.job_queue,
+            "jobDefinition": job_definition,
+            "containerOverrides": container_overrides,
+        }
+
+        tags = self._build_job_tags()
+        if tags:
+            job_params["tags"] = tags
+
+        # Mirror the optional kwargs from the dynamic path. The dynamic path bakes
+        # the timeout into the registered definition; here we have no definition to
+        # register, so the timeout travels as SubmitJob's top-level `timeout`
+        # field, which overrides any timeout on the pre-existing definition.
+        # Scheduling priority applies equally to pre-existing definitions.
+        # NOTE: any future kwarg added to submit() (e.g. propagateTags) must also
+        # be mirrored here.
+        task_timeout = self._resolve_task_timeout()
+        if task_timeout is not None:
+            job_params["timeout"] = {"attemptDurationSeconds": task_timeout}
+
+        priority = self._resolve_scheduling_priority()
+        if priority is not None:
+            job_params["schedulingPriorityOverride"] = priority
+
+        try:
+            submitted = self.batch_client.submit_job(**job_params)
+            submitted["_preexisting_job_definition"] = True
+            return submitted
+        except Exception as e:
+            raise WorkflowError(f"Failed to submit job: {e}") from e
+
     def submit(self):
+        preexisting = self._resolve_preexisting_job_definition()
+        if preexisting:
+            return self._submit_with_preexisting_definition(preexisting)
+
         job_def, job_name = self.build_job_definition()
 
         job_params = {
@@ -378,35 +577,9 @@ class BatchJobBuilder:
         if tags:
             job_params["tags"] = tags
 
-        # Per-rule scheduling priority override for fair-share queues. The
-        # aws_batch_scheduling_priority resource takes precedence over the
-        # workflow-level scheduling_priority setting. When neither is set the
-        # kwarg is omitted entirely so submissions are byte-identical to today
-        # on non-fair-share queues.
-        resource_priority = self.job.resources.get("aws_batch_scheduling_priority")
-        setting_priority = getattr(self.settings, "scheduling_priority", None)
-        if resource_priority is not None:
-            priority = resource_priority
-            priority_source = "aws_batch_scheduling_priority resource"
-        elif setting_priority is not None:
-            priority = setting_priority
-            priority_source = "--aws-batch-scheduling-priority setting"
-        else:
-            priority = None
-            priority_source = ""
+        priority = self._resolve_scheduling_priority()
         if priority is not None:
-            try:
-                priority_int = int(priority)
-            except (TypeError, ValueError) as e:
-                raise WorkflowError(
-                    f"Invalid {priority_source} {priority!r}: must be an integer."
-                ) from e
-            if not (0 <= priority_int <= 9999):
-                raise WorkflowError(
-                    f"Invalid {priority_source} {priority_int}: "
-                    "must be in range [0, 9999]."
-                )
-            job_params["schedulingPriorityOverride"] = priority_int
+            job_params["schedulingPriorityOverride"] = priority
 
         try:
             submitted = self.batch_client.submit_job(**job_params)

--- a/tests/test_batch_job_builder.py
+++ b/tests/test_batch_job_builder.py
@@ -304,15 +304,34 @@ class TestGetPlatformFromQueue:
             {"Error": {"Code": "AccessDeniedException", "Message": "no perm"}},
             "DescribeJobQueues",
         )
+        # Platform is resolved lazily, so the error surfaces on first access.
+        builder = self._build(batch_client)
         with pytest.raises(WorkflowError, match="Failed to determine platform"):
-            self._build(batch_client)
+            _ = builder.platform
 
     def test_unexpected_exception_propagates(self):
         """Unexpected (non-ClientError) exceptions must propagate."""
         batch_client = MagicMock()
         batch_client.describe_job_queues.side_effect = RuntimeError("boom")
+        builder = self._build(batch_client)
         with pytest.raises(RuntimeError, match="boom"):
-            self._build(batch_client)
+            _ = builder.platform
+
+    def test_platform_not_resolved_at_construction(self):
+        """Constructing a builder must not query the queue — resolution is lazy."""
+        batch_client = MagicMock()
+        batch_client.describe_job_queues.return_value = {"jobQueues": []}
+        self._build(batch_client)
+        batch_client.describe_job_queues.assert_not_called()
+
+    def test_platform_cached_after_first_access(self):
+        """The queue is queried once; subsequent accesses use the cached value."""
+        batch_client = MagicMock()
+        batch_client.describe_job_queues.return_value = {"jobQueues": []}
+        builder = self._build(batch_client)
+        _ = builder.platform
+        _ = builder.platform
+        batch_client.describe_job_queues.assert_called_once()
 
     def test_empty_queue_response_falls_back_to_ec2(self):
         """The explicit empty-response branch keeps the EC2 fallback."""
@@ -490,16 +509,18 @@ class TestErrorMessagesUseResolvedQueue:
             {"Error": {"Code": "AccessDeniedException", "Message": "no perm"}},
             "DescribeJobQueues",
         )
+        builder = BatchJobBuilder(
+            logger=MagicMock(),
+            job=self._make_job_with_queue_override(),
+            envvars={},
+            container_image="test-image:latest",
+            settings=self._make_settings(),
+            job_command="snakemake ...",
+            batch_client=batch_client,
+        )
+        # Platform is resolved lazily, so the error surfaces on first access.
         with pytest.raises(WorkflowError, match="override-queue"):
-            BatchJobBuilder(
-                logger=MagicMock(),
-                job=self._make_job_with_queue_override(),
-                envvars={},
-                container_image="test-image:latest",
-                settings=self._make_settings(),
-                job_command="snakemake ...",
-                batch_client=batch_client,
-            )
+            _ = builder.platform
 
     def test_fargate_rejection_reports_resolved_queue(self):
         """The Fargate fail-fast message must name the per-job override queue."""
@@ -1031,3 +1052,449 @@ class TestRunJobContainerImage:
         """With no per-rule resource, run_job must use the global container image."""
         image = _run_job_capture_container_image({})
         assert image == "global-image:latest"
+
+
+# ---------------------------------------------------------------------------
+# Tests for pre-existing job definitions (--aws-batch-job-definition)
+# ---------------------------------------------------------------------------
+
+
+def _make_builder_with_preexisting(
+    job_definition: str = "my-job-def",
+    resources: dict | None = None,
+    job_role: str | None = None,
+    envvars: dict | None = None,
+    threads: int = 2,
+) -> BatchJobBuilder:
+    """Return a BatchJobBuilder configured with a pre-existing job definition."""
+    if resources is None:
+        resources = {"_cores": 2, "mem_mb": 2048}
+    settings = SimpleNamespace(
+        job_queue="test-queue",
+        job_role=job_role,
+        job_definition=job_definition,
+        tags=None,
+        task_timeout=300,
+    )
+    batch_client = MagicMock()
+    batch_client.describe_job_queues.return_value = {"jobQueues": []}
+    job = MagicMock()
+    job.name = "test_rule"
+    job.threads = threads
+    job.resources = resources
+    return BatchJobBuilder(
+        logger=MagicMock(),
+        job=job,
+        envvars=envvars or {},
+        container_image="test-image:latest",
+        settings=settings,
+        job_command="snakemake --jobs 1",
+        batch_client=batch_client,
+    )
+
+
+class TestPreExistingJobDefinition:
+    """Pre-existing job definition mode: skip register, use containerOverrides."""
+
+    # --- submit uses supplied definition, no register call ---
+
+    def test_submit_uses_preexisting_definition_no_register(self):
+        """submit() must use the pre-existing definition and skip register."""
+        builder = _make_builder_with_preexisting(job_definition="my-job-def")
+        builder.batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+        }
+        builder.submit()
+        builder.batch_client.register_job_definition.assert_not_called()
+        call_kwargs = builder.batch_client.submit_job.call_args.kwargs
+        assert call_kwargs["jobDefinition"] == "my-job-def"
+
+    def test_submit_with_arn_definition(self):
+        """An ARN-form pre-existing definition must be passed through unchanged."""
+        arn = "arn:aws:batch:us-east-1:123456789012:job-definition/my-def:5"
+        builder = _make_builder_with_preexisting(job_definition=arn)
+        builder.batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+        }
+        builder.submit()
+        call_kwargs = builder.batch_client.submit_job.call_args.kwargs
+        assert call_kwargs["jobDefinition"] == arn
+
+    # --- containerOverrides carries command, env, vcpu, mem ---
+
+    def test_container_overrides_has_command(self):
+        builder = _make_builder_with_preexisting(job_definition="my-job-def")
+        builder.batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+        }
+        builder.submit()
+        call_kwargs = builder.batch_client.submit_job.call_args.kwargs
+        overrides = call_kwargs["containerOverrides"]
+        assert overrides["command"] == ["/bin/bash", "-c", "snakemake --jobs 1"]
+
+    def test_container_overrides_has_vcpu_and_mem(self):
+        builder = _make_builder_with_preexisting(
+            resources={"_cores": 4, "mem_mb": 8192}, threads=4
+        )
+        builder.batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+        }
+        builder.submit()
+        overrides = builder.batch_client.submit_job.call_args.kwargs[
+            "containerOverrides"
+        ]
+        req_by_type = {r["type"]: r["value"] for r in overrides["resourceRequirements"]}
+        assert req_by_type["VCPU"] == "4"
+        assert req_by_type["MEMORY"] == "8192"
+
+    def test_container_overrides_has_environment(self):
+        builder = _make_builder_with_preexisting(
+            job_definition="my-job-def",
+            envvars={"MY_VAR": "hello", "ANOTHER": "world"},
+        )
+        builder.batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+        }
+        builder.submit()
+        overrides = builder.batch_client.submit_job.call_args.kwargs[
+            "containerOverrides"
+        ]
+        env_map = {e["name"]: e["value"] for e in overrides.get("environment", [])}
+        assert env_map["MY_VAR"] == "hello"
+        assert env_map["ANOTHER"] == "world"
+
+    # --- tags flow through _build_job_tags() into submit_job ---
+
+    def test_tags_forwarded_in_preexisting_mode(self):
+        """Settings tags must reach submit_job via the same _build_job_tags() path."""
+        builder = _make_builder_with_preexisting(job_definition="my-job-def")
+        builder.settings.tags = {"Env": "prod", "Project": "fgumi"}
+        builder.batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+        }
+        builder.submit()
+        call_kwargs = builder.batch_client.submit_job.call_args.kwargs
+        assert call_kwargs["tags"] == {"Env": "prod", "Project": "fgumi"}
+
+    def test_container_overrides_no_gpu_when_zero(self):
+        """GPU must NOT appear in resourceRequirements when gpu == 0."""
+        builder = _make_builder_with_preexisting(
+            resources={"_cores": 2, "mem_mb": 2048, "_gpus": 0}
+        )
+        builder.batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+        }
+        builder.submit()
+        overrides = builder.batch_client.submit_job.call_args.kwargs[
+            "containerOverrides"
+        ]
+        types = [r["type"] for r in overrides["resourceRequirements"]]
+        assert "GPU" not in types
+
+    def test_container_overrides_includes_gpu_when_set(self):
+        """GPU must appear in resourceRequirements when gpu > 0."""
+        builder = _make_builder_with_preexisting(
+            resources={"_cores": 4, "mem_mb": 4096, "_gpus": 2}, threads=4
+        )
+        builder.batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+        }
+        builder.submit()
+        overrides = builder.batch_client.submit_job.call_args.kwargs[
+            "containerOverrides"
+        ]
+        req_by_type = {r["type"]: r["value"] for r in overrides["resourceRequirements"]}
+        assert req_by_type["GPU"] == "2"
+
+    # --- per-rule aws_batch_job_definition resource override ---
+
+    def test_per_rule_resource_overrides_setting(self):
+        """resources.aws_batch_job_definition overrides the settings value."""
+        builder = _make_builder_with_preexisting(
+            job_definition="default-def",
+            resources={
+                "_cores": 2,
+                "mem_mb": 2048,
+                "aws_batch_job_definition": "per-rule-def",
+            },
+        )
+        builder.batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+        }
+        builder.submit()
+        call_kwargs = builder.batch_client.submit_job.call_args.kwargs
+        assert call_kwargs["jobDefinition"] == "per-rule-def"
+        builder.batch_client.register_job_definition.assert_not_called()
+
+    # --- incompatible setting combinations raise WorkflowError ---
+
+    def test_job_role_plus_job_definition_raises(self):
+        """job_role + job_definition must raise WorkflowError immediately."""
+        builder = _make_builder_with_preexisting(
+            job_definition="my-job-def",
+            job_role="arn:aws:iam::123456789:role/my-role",
+        )
+        with pytest.raises(WorkflowError, match="job_role"):
+            builder.submit()
+        builder.batch_client.register_job_definition.assert_not_called()
+        builder.batch_client.submit_job.assert_not_called()
+
+    def test_shared_memory_size_mb_plus_job_definition_raises(self):
+        """shared_memory_size_mb + job_definition must raise WorkflowError."""
+        builder = _make_builder_with_preexisting(
+            job_definition="my-job-def",
+            resources={"_cores": 2, "mem_mb": 2048, "shared_memory_size_mb": 4096},
+        )
+        with pytest.raises(WorkflowError, match="shared_memory_size_mb"):
+            builder.submit()
+        builder.batch_client.register_job_definition.assert_not_called()
+        builder.batch_client.submit_job.assert_not_called()
+
+    def test_shared_memory_size_mb_zero_plus_job_definition_raises(self):
+        """An explicit shared_memory_size_mb=0 must also raise — the resource is
+        meaningless in pre-existing mode, and the dynamic path rejects 0 too."""
+        builder = _make_builder_with_preexisting(
+            job_definition="my-job-def",
+            resources={"_cores": 2, "mem_mb": 2048, "shared_memory_size_mb": 0},
+        )
+        with pytest.raises(WorkflowError, match="shared_memory_size_mb"):
+            builder.submit()
+        builder.batch_client.submit_job.assert_not_called()
+
+    # --- no platform discovery in pre-existing mode (smaller IAM surface) ---
+
+    def test_no_queue_platform_discovery_in_preexisting_mode(self):
+        """Pre-existing mode must not query the queue — that would force
+        DescribeJobQueues/DescribeComputeEnvironments IAM the mode aims to avoid."""
+        builder = _make_builder_with_preexisting(job_definition="my-job-def")
+        builder.batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+        }
+        builder.submit()
+        builder.batch_client.describe_job_queues.assert_not_called()
+        builder.batch_client.describe_compute_environments.assert_not_called()
+
+    # --- task timeout is mirrored into the pre-existing path ---
+
+    def test_task_timeout_forwarded_in_preexisting_mode(self):
+        """The dynamic path bakes timeout into the definition; pre-existing mode
+        must forward it as SubmitJob's top-level timeout field instead."""
+        builder = _make_builder_with_preexisting(job_definition="my-job-def")
+        builder.settings.task_timeout = 600
+        builder.batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+        }
+        builder.submit()
+        call_kwargs = builder.batch_client.submit_job.call_args.kwargs
+        assert call_kwargs["timeout"] == {"attemptDurationSeconds": 600}
+
+    def test_per_rule_task_timeout_overrides_setting_in_preexisting_mode(self):
+        """The aws_batch_task_timeout resource takes precedence over the setting."""
+        builder = _make_builder_with_preexisting(
+            job_definition="my-job-def",
+            resources={
+                "_cores": 2,
+                "mem_mb": 2048,
+                "aws_batch_task_timeout": 900,
+            },
+        )
+        builder.settings.task_timeout = 600
+        builder.batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+        }
+        builder.submit()
+        call_kwargs = builder.batch_client.submit_job.call_args.kwargs
+        assert call_kwargs["timeout"] == {"attemptDurationSeconds": 900}
+
+    def test_task_timeout_omitted_when_unset_in_preexisting_mode(self):
+        """No timeout field when neither resource nor setting is configured."""
+        builder = _make_builder_with_preexisting(job_definition="my-job-def")
+        builder.settings.task_timeout = None
+        builder.batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+        }
+        builder.submit()
+        call_kwargs = builder.batch_client.submit_job.call_args.kwargs
+        assert "timeout" not in call_kwargs
+
+    # --- no deregister for pre-existing definitions ---
+
+    def test_submitted_job_aux_marks_preexisting(self):
+        """Jobs submitted with a pre-existing definition must carry the
+        _preexisting_job_definition marker so deregister can skip them."""
+        builder = _make_builder_with_preexisting(job_definition="my-job-def")
+        builder.batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+        }
+        result = builder.submit()
+        assert result.get("_preexisting_job_definition") is True
+
+    # --- scheduling priority is mirrored into the pre-existing path ---
+
+    def test_scheduling_priority_forwarded_in_preexisting_mode(self):
+        """schedulingPriorityOverride must be mirrored from the dynamic path."""
+        builder = _make_builder_with_preexisting(job_definition="my-job-def")
+        builder.settings.scheduling_priority = 500
+        builder.batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+        }
+        builder.submit()
+        call_kwargs = builder.batch_client.submit_job.call_args.kwargs
+        assert call_kwargs["schedulingPriorityOverride"] == 500
+
+    def test_scheduling_priority_omitted_when_unset_in_preexisting_mode(self):
+        """schedulingPriorityOverride must be absent when no priority is set."""
+        builder = _make_builder_with_preexisting(job_definition="my-job-def")
+        builder.batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+        }
+        builder.submit()
+        call_kwargs = builder.batch_client.submit_job.call_args.kwargs
+        assert "schedulingPriorityOverride" not in call_kwargs
+
+    # --- default path unchanged when no pre-existing definition configured ---
+
+    def test_default_path_no_preexisting_def_still_registers(self):
+        """When job_definition is absent from settings, the dynamic path runs."""
+        builder = _make_builder(tags=None)  # settings has no job_definition attr
+        builder.batch_client.register_job_definition.return_value = _fake_job_def()
+        builder.batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+        }
+        builder.submit()
+        builder.batch_client.register_job_definition.assert_called_once()
+
+    def test_settings_job_definition_none_uses_dynamic_path(self):
+        """Explicit job_definition=None must fall through to the dynamic path."""
+        settings = SimpleNamespace(
+            job_queue="test-queue",
+            job_role="arn:aws:iam::123456789:role/role",
+            job_definition=None,
+            tags=None,
+            task_timeout=300,
+        )
+        batch_client = MagicMock()
+        batch_client.describe_job_queues.return_value = {"jobQueues": []}
+        batch_client.register_job_definition.return_value = _fake_job_def()
+        batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+        }
+        job = MagicMock()
+        job.name = "test_rule"
+        job.threads = 1
+        job.resources = {"_cores": 1, "mem_mb": 1024}
+        builder = BatchJobBuilder(
+            logger=MagicMock(),
+            job=job,
+            envvars={},
+            container_image="test-image:latest",
+            settings=settings,
+            job_command="snakemake ...",
+            batch_client=batch_client,
+        )
+        builder.submit()
+        batch_client.register_job_definition.assert_called_once()
+
+
+class TestDeregisterSkipsPreexisting:
+    """Executor._deregister_job must skip jobs that used a pre-existing definition."""
+
+    def _make_executor(self):
+        """Return a minimal Executor-like object with a real _deregister_job method."""
+        from snakemake_executor_plugin_aws_batch import Executor
+
+        executor = object.__new__(Executor)
+        executor.logger = MagicMock()
+        executor.batch_client = MagicMock()
+        return executor
+
+    def test_deregister_skipped_for_preexisting(self):
+        """_deregister_job must skip deregistration when _preexisting flag set."""
+        executor = self._make_executor()
+        job = MagicMock()
+        job.aux = {
+            "job_definition_arn": "arn:aws:batch:::job-definition/my-def:1",
+            "_preexisting_job_definition": True,
+        }
+        executor._deregister_job(job)
+        executor.batch_client.deregister_job_definition.assert_not_called()
+
+    def test_deregister_skip_logged_at_debug(self):
+        """Skipping a pre-existing definition must be logged at debug so operators
+        can tell why nothing was deregistered."""
+        executor = self._make_executor()
+        job = MagicMock()
+        job.aux = {
+            "job_definition_arn": "arn:aws:batch:::job-definition/my-def:1",
+            "_preexisting_job_definition": True,
+        }
+        executor._deregister_job(job)
+        executor.logger.debug.assert_called_once()
+        assert (
+            "skipping deregistration" in executor.logger.debug.call_args.args[0].lower()
+        )
+
+    def test_deregister_runs_for_dynamic_definition(self):
+        """_deregister_job must call deregister_job_definition for dynamic defs."""
+        executor = self._make_executor()
+        job = MagicMock()
+        job.aux = {
+            "job_definition_arn": "arn:aws:batch:::job-definition/snakejob-def:1",
+        }
+        executor._deregister_job(job)
+        executor.batch_client.deregister_job_definition.assert_called_once_with(
+            jobDefinition="arn:aws:batch:::job-definition/snakejob-def:1"
+        )
+
+    def test_marker_survives_real_flow_end_to_end(self):
+        """The _preexisting_job_definition marker must survive the full submit →
+        SubmittedJobInfo → _interpret_job_status aux-write → _deregister_job chain.
+
+        This locks the marker-survival property against a future refactor that
+        reassigns job.aux wholesale: if the marker is ever lost between submit() and
+        _deregister_job(), this test will catch it.
+        """
+        from snakemake_interface_executor_plugins.executors.base import SubmittedJobInfo
+
+        # 1. Call submit() in pre-existing mode with a mocked batch client.
+        builder = _make_builder_with_preexisting(job_definition="my-job-def")
+        builder.batch_client.submit_job.return_value = {
+            "jobName": "snakejob-test",
+            "jobId": "abc-123",
+        }
+        job_info = builder.submit()
+
+        # 2. Build SubmittedJobInfo exactly as run_job does.
+        mock_job = MagicMock()
+        submitted = SubmittedJobInfo(
+            job=mock_job, external_jobid=job_info["jobId"], aux=dict(job_info)
+        )
+
+        # 3. Simulate _interpret_job_status's in-place aux write (the real code
+        #    writes individual keys into the existing dict, not a reassignment).
+        submitted.aux[
+            "job_definition_arn"
+        ] = "arn:aws:batch:us-east-1:123456789012:job-definition/my-job-def:1"
+
+        # 4. Call _deregister_job and assert deregistration was skipped.
+        executor = self._make_executor()
+        executor._deregister_job(submitted)
+        executor.batch_client.deregister_job_definition.assert_not_called()


### PR DESCRIPTION
## Summary

The plugin always registered (and later deregistered) a fresh job definition per job — flexible, but it requires `batch:RegisterJobDefinition`/`DeregisterJobDefinition` IAM that security-conscious accounts refuse, churns thousands of single-use revisions, and keeps resource config out of infra review. A new optional `--aws-batch-job-definition <name|name:rev|ARN>` setting (with a per-rule `aws_batch_job_definition` resource override, mirroring `batch_queue`) switches to static mode:

- No `RegisterJobDefinition` call; per-job specifics travel via `containerOverrides` (`command`, `environment`, vcpu/mem `resourceRequirements`, GPU only when >0 — same resource extraction as the dynamic path)
- Submitted jobs are marked `_preexisting_job_definition` (carried through `run_job`'s `aux=dict(job_info)`), and every deregister/cleanup path skips them — we never deregister a definition we didn't register
- Fail-fast `WorkflowError` when combined with `job_role` or `shared_memory_size_mb` (build-only knobs); `container_image` is documented-ignored since its default is indistinguishable from explicit
- Tags flow through the same `_build_job_tags()` as the dynamic path
- The optional submit kwargs the dynamic path applies are mirrored via shared resolvers: task timeout travels as `SubmitJob`'s top-level `timeout` field (the dynamic path bakes it into the definition), and scheduling priority forwards `schedulingPriorityOverride` identically
- Platform (EC2/FARGATE) discovery is resolved lazily, so pre-existing mode never queries the queue — keeping its IAM surface free of `DescribeJobQueues`/`DescribeComputeEnvironments`
- The default (dynamic) path is byte-identical to before

## Test Plan

- [x] New tests (`TestPreExistingJobDefinition`, `TestDeregisterSkipsPreexisting`), including an end-to-end marker-survival test through the real `submit → SubmittedJobInfo(aux=…) → _interpret_job_status aux write → _deregister_job` chain, plus timeout/scheduling-priority mirroring and lazy-platform coverage
- [x] Full builder suite green (98 tests); black clean; flake8 clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for submitting jobs using a pre-existing AWS Batch job definition (name, revision, or ARN), with per-job overrides applied via container overrides when applicable.
  * Kept timeout and scheduling priority behavior consistent, and documented rule-level overrides.
* **Bug Fixes**
  * Prevent cleanup from deregistering externally managed job definitions.
  * Added early validation for incompatible option/resource combinations so submission fails fast.
* **Documentation**
  * Added a new guide section explaining “Pre-existing Job Definitions,” accepted formats, overrides, and incompatibilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->