### PR TITLE
ci: run all unit tests in the mocked-API job

### DIFF
--- a/.github/workflows/ci_mocked_api.yml
+++ b/.github/workflows/ci_mocked_api.yml
@@ -102,7 +102,7 @@ jobs:
         env:
           SNAKEMAKE_AWS_BATCH_JOB_QUEUE: "${{ secrets.SNAKEMAKE_AWS_BATCH_JOB_QUEUE }}"
           SNAKEMAKE_AWS_BATCH_JOB_ROLE: "${{ secrets.SNAKEMAKE_AWS_BATCH_JOB_ROLE }}"
-        run: poetry run coverage run -m pytest tests/tests_mocked_api.py tests/test_batch_job_builder.py -v
+        run: poetry run coverage run -m pytest tests/ --ignore=tests/tests_true_api.py -v
 
       - name: Run Coverage
         run: poetry run coverage report -m


### PR DESCRIPTION
The mocked-API CI job invoked pytest with an explicit file list (`tests/tests_mocked_api.py tests/test_batch_job_builder.py`), which silently omits any new test module added to the suite and has needed hand-editing more than once. Replace it with a directory invocation that runs everything under `tests/` except the live-AWS suite (which needs real credentials):

```
pytest tests/ --ignore=tests/tests_true_api.py -v
```

All workflow services and environment variables are preserved; only the pytest selection changes. On `main` today this selects the same two files — it future-proofs the invocation against the recurring list-rot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the continuous integration test run to execute the full test suite, while skipping one API-dependent test file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->