### PR TITLE
feat: support snakemake 9

### DIFF
--- a/.github/workflows/ci_mocked_api.yml
+++ b/.github/workflows/ci_mocked_api.yml
@@ -70,6 +70,14 @@ jobs:
 
   testing:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Exercise both supported snakemake majors. The two legs resolve to
+        # different snakemake-interface-storage-plugins majors (3.x vs 4.x, via
+        # snakemake-storage-plugin-s3), so passing on one does not imply the other.
+        snakemake: ["<9", ">=9,<10"]
+    name: testing (snakemake ${{ matrix.snakemake }})
     steps:
       - uses: actions/checkout@v3
 
@@ -80,8 +88,11 @@ jobs:
       - name: Install poetry
         run: pip install poetry
 
-      - name: Determine dependencies
-        run: poetry lock
+      - name: Constrain snakemake for this matrix leg
+        # A full re-resolve (not an overlay install) is required: the snakemake
+        # major dictates the storage-interface major, which in turn pins a
+        # compatible snakemake-storage-plugin-s3 version.
+        run: poetry add --group dev --lock "snakemake@${{ matrix.snakemake }}"
 
       - uses: actions/setup-python@v4
         with:

--- a/docs/further.md
+++ b/docs/further.md
@@ -91,15 +91,16 @@ snakemake --jobs 4 \
 
 # Container Image Requirements
 
-The plugin does **not** auto-deploy the default storage provider to workers
-(`auto_deploy_default_storage_provider=False`): workers no longer run
-`pip install snakemake-storage-plugin-s3` at startup, because that pulls an
-unpinned version whose newer releases require snakemake >= 9 and break
-workers running snakemake 8.x. The container image used for jobs must
-therefore pre-install a compatible version of the storage plugin (e.g.
-`snakemake-storage-plugin-s3`) alongside snakemake itself. Image maintainers
-are responsible for pinning a plugin version compatible with the snakemake
-version in the image.
+The plugin supports Snakemake 8 and 9 and does **not** auto-deploy the default
+storage provider to workers (`auto_deploy_default_storage_provider=False`):
+workers do not run `pip install snakemake-storage-plugin-s3` at startup, because
+an unpinned install can pull a storage-plugin version whose
+`snakemake-interface-storage-plugins` requirement does not match the Snakemake
+major baked into the image, breaking the worker (Snakemake 8 needs a plugin
+built against `snakemake-interface-storage-plugins` 3.x; Snakemake 9, one built
+against 4.x). The container image used for jobs must therefore pre-install a
+storage-plugin version compatible with its Snakemake version. Image maintainers
+are responsible for pinning a compatible pair.
 
 # Scheduling Priority (Fair-Share Queues)
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,2 +1,4 @@
 This is the Snakemake plugin for [AWS Batch](https://aws.amazon.com/batch/). This plugin 
 is used to distribute Snakemake jobs to AWS Batch EC2 instances.
+
+This plugin supports Snakemake 8 and 9.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,11 @@ black = "^23.11.0"
 flake8 = "^6.1.0"
 coverage = "^7.3.2"
 pytest = "^7.4.3"
-snakemake = "^8.30.0"
+# Support both snakemake 8 and 9. The executor talks to snakemake only through
+# snakemake-interface-executor-plugins (pinned in the runtime deps above), whose
+# contract is identical across 8 and 9, so no source changes are needed. CI's
+# testing matrix constrains this per leg to exercise both majors.
+snakemake = ">=8.30,<10"
 
 [tool.coverage.run]
 omit = [".*", "*/site-packages/*", "Snakefile"]


### PR DESCRIPTION
Documents and tests support for Snakemake 9 alongside Snakemake 8. The plugin already worked under Snakemake 9 but was untested and undocumented against it; this makes that support explicit and guarded.

The executor interacts with Snakemake exclusively through `snakemake-interface-executor-plugins`, whose contract is **identical** across Snakemake 8 and 9 (both pin `>=9.3.2,<10`). No source-code or runtime-dependency changes are required.

## Changes

- `pyproject.toml`: widen the **dev** `snakemake` pin `^8.30.0` → `>=8.30,<10` (dev-only; no end-user effect).
- `ci_mocked_api.yml`: add a `snakemake: ["<9", ">=9,<10"]` test matrix. Each leg does a full re-resolve via `poetry add --group dev --lock` rather than an overlay install, because the Snakemake major dictates the `snakemake-interface-storage-plugins` major (3.x vs 4.x), which selects a compatible `snakemake-storage-plugin-s3`. Passing on one major does not imply the other.
- `docs/`: state supported versions (8 and 9) and make the container-image storage-plugin guidance symmetric across both majors.

## Verified locally

Installed against Snakemake 9.23.1 (resolves s3 0.3.6 / storage-interface 4.4.1 / executor-plugins 9.4.0); plugin imports, subclasses `RemoteExecutor`, registers as `aws-batch` in Snakemake 9's `ExecutorPluginRegistry`, and passes all 101 `test_batch_job_builder.py` unit tests. Both matrix legs resolve to consistent sets:

| leg | snakemake | s3 | storage-interface |
|---|---|---|---|
| `<9` | 8.30.0 | 0.3.1 | 3.5.0 |
| `>=9,<10` | 9.23.1 | 0.3.6 | 4.4.1 |

## Out of scope

No runtime-dependency changes: the existing `snakemake-storage-plugin-s3 >=0.2,<0.4` pin already resolves correctly for both majors. Re-pinning CI actions by SHA and any storage-dependency restructuring are left to separate PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified support for Snakemake versions 8 and 9.
  * Updated container image guidance to explain compatibility requirements between Snakemake and storage-plugin versions.
  * Clarified that job images should pre-install a storage plugin compatible with their Snakemake version.

* **Tests**
  * CI now validates the project against both supported Snakemake major-version ranges.
  * Added checks confirming each test run uses the intended Snakemake major version.
  * Improved MinIO service readiness checks during CI runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->