### PR TITLE
feat: opt-in coordinator mode — run the workflow driver as an AWS Batch job

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -250,3 +250,98 @@ Task timeout and scheduling priority **are** still honored: `--aws-batch-task-ti
 resource) travel as `SubmitJob`'s top-level `timeout` and `schedulingPriorityOverride`
 fields, so they apply to pre-existing definitions just as they do to dynamically
 registered ones.
+
+# Coordinator Mode (opt-in)
+
+By default, the Snakemake **driver** (the scheduler that computes the DAG and
+submits/monitors worker jobs) runs **locally** — which ties your terminal or a
+login node to the whole workflow's lifetime. Coordinator mode is the **opt-in**
+alternative: it submits a single Batch job — the *coordinator* — whose command
+runs Snakemake in the cloud, then exits, so the local terminal can disconnect.
+The coordinator drives the workflow with the **full** Snakemake feature set
+(checkpoints, temp-file handling, live scheduling and retries) and submits worker
+jobs to Batch exactly as a local run would. Default behavior is unchanged; you
+opt in by using the launcher instead of running `snakemake` directly.
+
+## Usage
+
+```bash
+snakemake-aws-batch-coordinator \
+    --aws-batch-region us-east-1 \
+    --aws-batch-job-queue arn:aws:batch:...:job-queue/workers \
+    --aws-batch-job-role arn:aws:iam::...:role/snakemake-job-role \
+    --aws-batch-coordinator-queue arn:aws:batch:...:job-queue/coordinator-ondemand \
+    --default-storage-provider s3 \
+    --default-storage-prefix s3://my-bucket/prefix \
+    -- -s Snakefile my_target
+```
+
+Everything after `--` is your normal workflow invocation (snakefile, targets,
+config, ...). Monitor the run from the coordinator's Batch job (see
+*Observability* below). A few optional flags refine the run:
+
+- `--aws-batch-coordinator-status-prefix s3://…` — S3 base for the coordinator's
+  log, `.snakemake/` metadata, and a `status.json`, written per run under
+  `AWS_BATCH_JOB_ID`. Defaults to `<default-storage-prefix>/.coordinator`.
+- `--aws-batch-coordinator-notify-sns-topic arn:aws:sns:…` — publish a
+  completion/failure notification to this SNS topic.
+- `--aws-batch-container-image <image>` — the container image used to run
+  Snakemake. It is applied to **both** the coordinator job and the worker jobs
+  it submits, so the coordinator drives the workflow with the same image the
+  workers use.
+
+## How it works
+
+The launcher is intentionally built on **native** Snakemake — there is no
+scheduler hijack and no hard process exit:
+
+1. It writes a *wrapper* workflow that `include:`s your real workflow (so
+   Snakemake discovers and deploys its sources — snakefiles and scripts — with
+   the coordinator job) and defines a single **no-output** rule whose command
+   runs your real invocation in the cloud.
+2. It runs that wrapper with `--immediate-submit --notemp`, targeting only the
+   no-output rule. Snakemake natively submits the one job and exits **without
+   polling**; the no-output rule means no output verification on the
+   fire-and-forget coordinator job, and the included real rules are parsed but
+   not run locally.
+3. The coordinator job pulls the deployed sources from storage (the executor
+   sets `job_deploy_sources`) and runs the real workflow.
+
+The coordinator container must have `python` and `snakemake` on `PATH` with this
+plugin installed (the published runtime image satisfies this). Note that
+`include:`-ing your workflow means its top-level code (e.g. `configfile:`) is
+evaluated locally when the coordinator is submitted, so run the launcher from the
+workflow directory as you would `snakemake`.
+
+## Run the coordinator on on-demand capacity
+
+`--aws-batch-coordinator-queue` defaults to the worker `--aws-batch-job-queue`,
+but you should point it at an **on-demand** queue. Workers can be Spot (cheap,
+interruptible) because the coordinator resubmits them on interruption — but the
+coordinator itself is the driver, and a Spot reclaim of the coordinator tears
+down the whole run (its in-flight state lives in the container).
+
+## Observability and failure semantics
+
+Coordinator mode is *fire-and-forget*, so it changes what completion means:
+
+- **The local exit code means "coordinator submitted", not "workflow
+  succeeded".** Do not gate CI on it. Track the outcome via the coordinator's
+  Batch job status.
+- **Logs:** the coordinator job's Snakemake output streams to **CloudWatch Logs**
+  (`/aws/batch/job`) automatically, via Batch's default log driver — view it with
+  the console or `aws logs tail`.
+- **Durable log + metadata + notification:** the coordinator job runs Snakemake
+  through an in-job wrapper
+  (`snakemake_executor_plugin_aws_batch.coordinator_runner`) that, on exit,
+  uploads the driver log and the resume-relevant `.snakemake/` state
+  (`metadata/` and `incomplete/`; heavy caches and `locks/` are skipped) to the
+  status prefix on S3 and, if configured, publishes an SNS notification with the
+  outcome. Because that wrapper is the *parent* process, it survives an
+  inner-Snakemake crash or OOM and still records the result — only an
+  instance-level failure escapes it (another reason to run the coordinator on
+  on-demand).
+- **Recovery:** the synced `.snakemake/` and the durable outputs in S3 let a
+  re-run resume; provenance-based rerun triggers that depend on the ephemeral
+  metadata may still be lost. Prefer Batch `attempts=1` for the coordinator so a
+  failure surfaces rather than silently re-running with amnesia.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,15 +16,24 @@ snakemake-interface-common = "^1.17.4"
 snakemake-interface-executor-plugins = "^9.3.2"
 snakemake-storage-plugin-s3 = ">=0.2,<0.4"
 
+[tool.poetry.scripts]
+# Opt-in launcher: submit a workflow's driver ("coordinator") as an AWS Batch
+# job and exit, instead of running the Snakemake scheduler locally.
+snakemake-aws-batch-coordinator = "snakemake_executor_plugin_aws_batch.coordinator:main"
+
 [tool.poetry.group.dev.dependencies]
 black = "^23.11.0"
 flake8 = "^6.1.0"
 coverage = "^7.3.2"
 pytest = "^7.4.3"
 snakemake = "^8.30.0"
+moto = {extras = ["batch", "s3"], version = "^5.0"}
 
 [tool.coverage.run]
-omit = [".*", "*/site-packages/*", "Snakefile"]
+# Snakefiles (Snakefile, *.smk) are Snakemake workflow files, not Python source
+# for coverage — omit them anywhere so `coverage report` never tries to parse a
+# workflow file that a test loaded (e.g. the coordinator's generated wrapper).
+omit = [".*", "*/site-packages/*", "Snakefile", "*/Snakefile", "*.smk"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/snakemake_executor_plugin_aws_batch/coordinator.py
+++ b/snakemake_executor_plugin_aws_batch/coordinator.py
@@ -1,0 +1,334 @@
+"""Opt-in launcher that runs a workflow's driver ("coordinator") on AWS Batch.
+
+By default you run Snakemake normally — the scheduler runs **locally** and submits
+worker jobs to AWS Batch. That ties your terminal (or a login node) to the whole
+workflow's lifetime. This launcher is the **opt-in** alternative: it submits a
+single Batch job — the *coordinator* — whose command runs Snakemake in the cloud,
+then exits, so the local terminal is free to disconnect. The coordinator drives
+the workflow with the **full** Snakemake feature set (checkpoints, temp handling,
+live scheduling/retries), submitting worker jobs to Batch exactly as a local run
+would.
+
+Mechanism — deliberately built on native Snakemake, with no scheduler hijack and
+no ``os._exit``:
+
+1. Write a one-rule *wrapper* workflow whose single rule's shell command is your
+   real Snakemake invocation.
+2. Run that wrapper with ``--executor aws-batch --immediate-submit --notemp``.
+   Snakemake natively submits the one job and exits (it does not poll). The
+   wrapper rule has **no output**, so Snakemake performs no output verification
+   on the fire-and-forget coordinator job.
+3. The coordinator job pulls the workflow sources from storage (the plugin sets
+   ``job_deploy_sources``) and runs the real workflow.
+
+Because this is just "submit one Batch job and exit," the local exit code means
+*submitted*, not *workflow-succeeded* — monitor the coordinator via its Batch job
+status and logs (CloudWatch, and optionally S3 via the coordinator wrapper
+script). Run the coordinator on an **on-demand** queue: a Spot reclaim of the
+coordinator would take down the whole driver.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+# Name of the single rule in the generated wrapper workflow. It has no output,
+# so Snakemake schedules it whenever targeted by name and never tries to verify
+# an output file for the fire-and-forget coordinator job. The name is
+# deliberately unlikely so it does not collide with a rule in the included
+# real workflow.
+COORDINATOR_RULE = "_aws_batch_coordinator_submit"
+
+# A distinctive wrapper-Snakefile name written into the project directory so it
+# is deployed to storage alongside the real workflow (job_deploy_sources).
+WRAPPER_SNAKEFILE_NAME = ".snakemake_aws_batch_coordinator.smk"
+
+# Interpreter used to invoke the in-job runner INSIDE the coordinator container.
+# Must be on PATH there (the published runtime image provides it).
+COORDINATOR_INTERPRETER = "python"
+
+# Snakemake's default snakefile search order, used when the workflow args don't
+# pass one explicitly (mirrors Snakemake's own resolution, incl. workflow/).
+DEFAULT_SNAKEFILE_CANDIDATES = (
+    "Snakefile",
+    "snakefile",
+    "workflow/Snakefile",
+    "workflow/snakefile",
+)
+
+
+def _real_snakefile(
+    workflow_args: Sequence[str], directory: Optional[Path] = None
+) -> str:
+    """Extract the real workflow's snakefile path from the passthrough args.
+
+    The wrapper ``include:``s this so Snakemake discovers and deploys the real
+    workflow's sources (snakefiles + scripts) with the coordinator job. When no
+    ``-s``/``--snakefile`` is given, resolve Snakemake's default search order
+    (including the ``workflow/`` layout) against ``directory``.
+    """
+    args = list(workflow_args)
+    for i, arg in enumerate(args):
+        if arg in ("-s", "--snakefile") and i + 1 < len(args):
+            return args[i + 1]
+        if arg.startswith("--snakefile="):
+            return arg.split("=", 1)[1]
+        if arg.startswith("-s") and len(arg) > 2:  # -sSnakefile
+            return arg[2:]
+    base = directory or Path.cwd()
+    for candidate in DEFAULT_SNAKEFILE_CANDIDATES:
+        if (base / candidate).exists():
+            return candidate
+    return DEFAULT_SNAKEFILE_CANDIDATES[0]
+
+
+@dataclass(frozen=True)
+class CoordinatorConfig:
+    """Connection + storage configuration shared by the coordinator and workers."""
+
+    region: str
+    job_queue: str
+    job_role: str
+    default_storage_provider: str
+    default_storage_prefix: str
+    container_image: Optional[str] = None
+    # Queue for the coordinator job itself. Defaults to job_queue, but should be
+    # an ON-DEMAND queue: the coordinator is the driver, and a Spot reclaim would
+    # tear down the whole run. Workers can still be Spot via job_queue.
+    coordinator_queue: Optional[str] = None
+    # S3 base for the coordinator's log + metadata + status.json (per run, under
+    # AWS_BATCH_JOB_ID). Defaults to "<default_storage_prefix>/.coordinator".
+    status_s3_prefix: Optional[str] = None
+    # Optional SNS topic ARN for a completion/failure notification.
+    notify_sns_topic: Optional[str] = None
+
+
+def strip_remainder_separator(args: Sequence[str]) -> List[str]:
+    """Drop the leading ``--`` that ``argparse.REMAINDER`` captures into the list."""
+    args = list(args)
+    return args[1:] if args and args[0] == "--" else args
+
+
+def _status_s3_prefix(config: "CoordinatorConfig") -> str:
+    if config.status_s3_prefix:
+        return config.status_s3_prefix
+    return config.default_storage_prefix.rstrip("/") + "/.coordinator"
+
+
+def _shared_snakemake_args(config: CoordinatorConfig, *, queue: str) -> List[str]:
+    """Return the aws-batch + storage flags common to inner and outer commands.
+
+    The caller passes the target ``queue``: the outer (local) submission uses the
+    coordinator (on-demand) queue so the coordinator job lands there; the inner
+    command (run inside the coordinator) uses the worker job queue.
+    """
+    args = [
+        "--executor",
+        "aws-batch",
+        "--aws-batch-region",
+        config.region,
+        "--aws-batch-job-queue",
+        queue,
+        "--aws-batch-job-role",
+        config.job_role,
+        "--default-storage-provider",
+        config.default_storage_provider,
+        "--default-storage-prefix",
+        config.default_storage_prefix,
+    ]
+    if config.container_image:
+        args += ["--aws-batch-container-image", config.container_image]
+    return args
+
+
+def _inner_command_parts(
+    config: CoordinatorConfig, workflow_args: Sequence[str]
+) -> List[str]:
+    """The real workflow's Snakemake argv, run inside the coordinator job."""
+    return [
+        "snakemake",
+        *_shared_snakemake_args(config, queue=config.job_queue),
+        *workflow_args,
+    ]
+
+
+def build_coordinator_command(
+    config: CoordinatorConfig, workflow_args: Sequence[str]
+) -> str:
+    """Return the wrapper rule's command: the runner wrapping the inner command.
+
+    The coordinator job runs the in-job runner
+    (:mod:`snakemake_executor_plugin_aws_batch.coordinator_runner`), which execs
+    the real workflow and, on exit, persists the log + ``.snakemake/`` metadata to
+    S3 and optionally notifies — surviving an inner-Snakemake crash/OOM.
+    """
+    runner = [
+        COORDINATOR_INTERPRETER,
+        "-m",
+        "snakemake_executor_plugin_aws_batch.coordinator_runner",
+        "--status-s3-prefix",
+        _status_s3_prefix(config),
+    ]
+    if config.notify_sns_topic:
+        runner += ["--sns-topic-arn", config.notify_sns_topic]
+    runner.append("--")
+    return shlex.join(runner + _inner_command_parts(config, workflow_args))
+
+
+def write_wrapper_snakefile(
+    coordinator_command: str, directory: Path, real_snakefile: str
+) -> Path:
+    """Write the wrapper workflow and return its path.
+
+    The wrapper ``include:``s the real workflow so Snakemake discovers and deploys
+    its sources (snakefiles + scripts) with the coordinator job, then defines a
+    single **no-output** rule whose command submits the run in the cloud. The
+    no-output rule is what lets ``--immediate-submit`` submit-and-exit without
+    waiting for an output file. Only the coordinator rule is targeted, so the
+    included real rules are parsed but not run locally.
+    """
+    path = directory / WRAPPER_SNAKEFILE_NAME
+    # Snakemake formats a `shell:` string against the job namespace (wildcards,
+    # params, ...), so any literal `{`/`}` in the command — e.g. a brace inside a
+    # user `--config` value, storage prefix, or workflow arg — must be doubled or
+    # it is parsed as a format field and raises at rule-execution time.
+    escaped_command = coordinator_command.replace("{", "{{").replace("}", "}}")
+    path.write_text(
+        "# Auto-generated by the aws-batch coordinator launcher.\n"
+        "# Includes the real workflow (so its sources deploy with the coordinator\n"
+        "# job) and submits one no-output rule that runs it in the cloud.\n"
+        f"rule {COORDINATOR_RULE}:\n"
+        f"    shell:\n"
+        f"        {escaped_command!r}\n"
+        f"\n"
+        f"include: {real_snakefile!r}\n"
+    )
+    return path
+
+
+def build_outer_command(
+    config: CoordinatorConfig, wrapper_snakefile: Path
+) -> List[str]:
+    """Build the local Snakemake command that submits the coordinator and exits.
+
+    Uses ``--immediate-submit`` (submit-and-exit, no polling) and ``--notemp``
+    (required by immediate-submit), targeting the no-output coordinator rule on
+    the coordinator (on-demand) queue.
+    """
+    return [
+        "snakemake",
+        *_shared_snakemake_args(
+            config, queue=config.coordinator_queue or config.job_queue
+        ),
+        "--immediate-submit",
+        "--notemp",
+        "--jobs",
+        "1",
+        "--snakefile",
+        str(wrapper_snakefile),
+        COORDINATOR_RULE,
+    ]
+
+
+def launch(
+    config: CoordinatorConfig,
+    workflow_args: Sequence[str],
+    *,
+    project_dir: Optional[Path] = None,
+    runner=subprocess.run,
+) -> int:
+    """Generate the wrapper workflow and submit the coordinator job.
+
+    Returns the exit code of the local submission run. A zero exit means the
+    coordinator was **submitted** (not that the workflow succeeded).
+    ``runner`` is injectable for testing.
+    """
+    directory = project_dir or Path.cwd()
+    coordinator_command = build_coordinator_command(config, workflow_args)
+    wrapper = write_wrapper_snakefile(
+        coordinator_command, directory, _real_snakefile(workflow_args, directory)
+    )
+    try:
+        outer = build_outer_command(config, wrapper)
+        print(
+            "Submitting the workflow coordinator to AWS Batch "
+            "(the terminal can disconnect once it is queued)...",
+            file=sys.stderr,
+        )
+        completed = runner(outer)
+        return getattr(completed, "returncode", 0)
+    finally:
+        wrapper.unlink(missing_ok=True)
+
+
+def _parse_args(argv: Sequence[str]) -> tuple[CoordinatorConfig, List[str]]:
+    parser = argparse.ArgumentParser(
+        prog="snakemake-aws-batch-coordinator",
+        description=(
+            "Submit a Snakemake workflow's driver (coordinator) as an AWS Batch "
+            "job and exit. Pass the real workflow arguments after `--`."
+        ),
+    )
+    parser.add_argument("--aws-batch-region", required=True, dest="region")
+    parser.add_argument("--aws-batch-job-queue", required=True, dest="job_queue")
+    parser.add_argument("--aws-batch-job-role", required=True, dest="job_role")
+    parser.add_argument(
+        "--aws-batch-coordinator-queue",
+        dest="coordinator_queue",
+        default=None,
+        help="On-demand queue for the coordinator job (defaults to the worker "
+        "queue; a Spot reclaim of the coordinator would kill the whole run).",
+    )
+    parser.add_argument(
+        "--aws-batch-container-image", dest="container_image", default=None
+    )
+    parser.add_argument(
+        "--aws-batch-coordinator-status-prefix",
+        dest="status_s3_prefix",
+        default=None,
+        help="S3 base for the coordinator's log/metadata/status (per run, under "
+        "AWS_BATCH_JOB_ID). Defaults to '<default-storage-prefix>/.coordinator'.",
+    )
+    parser.add_argument(
+        "--aws-batch-coordinator-notify-sns-topic",
+        dest="notify_sns_topic",
+        default=None,
+        help="Optional SNS topic ARN for a coordinator completion/failure "
+        "notification.",
+    )
+    parser.add_argument("--default-storage-provider", required=True)
+    parser.add_argument("--default-storage-prefix", required=True)
+    parser.add_argument(
+        "workflow_args",
+        nargs=argparse.REMAINDER,
+        help="The real workflow arguments, after `--` (e.g. -s Snakefile targets).",
+    )
+    ns = parser.parse_args(argv)
+    workflow_args = strip_remainder_separator(ns.workflow_args)
+    config = CoordinatorConfig(
+        region=ns.region,
+        job_queue=ns.job_queue,
+        job_role=ns.job_role,
+        default_storage_provider=ns.default_storage_provider,
+        default_storage_prefix=ns.default_storage_prefix,
+        container_image=ns.container_image,
+        coordinator_queue=ns.coordinator_queue,
+        status_s3_prefix=ns.status_s3_prefix,
+        notify_sns_topic=ns.notify_sns_topic,
+    )
+    return config, workflow_args
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    config, workflow_args = _parse_args(sys.argv[1:] if argv is None else argv)
+    return launch(config, workflow_args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/snakemake_executor_plugin_aws_batch/coordinator_runner.py
+++ b/snakemake_executor_plugin_aws_batch/coordinator_runner.py
@@ -1,0 +1,219 @@
+"""In-coordinator wrapper: run Snakemake, then persist its log + metadata + notify.
+
+This runs *inside* the coordinator Batch job, wrapping the real Snakemake
+invocation. Because it is the **parent** process, it survives an inner-Snakemake
+crash or OOM and still, on exit:
+
+1. uploads the driver's combined stdout/stderr log to S3,
+2. syncs the resume-relevant ``.snakemake/`` state to S3 (``metadata/`` and
+   ``incomplete/`` — deliberately skipping ``locks/`` and heavy caches like
+   ``conda/``/``singularity/``/``shadow/``), and
+3. optionally publishes an SNS notification carrying the outcome.
+
+Everything is written under ``<status prefix>/<AWS_BATCH_JOB_ID>/`` so each
+coordinator run is isolated. Only an instance-level failure (e.g. a Spot reclaim
+of the coordinator host, which sends SIGKILL with no grace) escapes this — a
+reason to run the coordinator on on-demand capacity.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+from snakemake_executor_plugin_aws_batch.coordinator import strip_remainder_separator
+
+# .snakemake/ subdirectories worth uploading — the resume-relevant state. An
+# allowlist (rather than an exclude list) deliberately skips the heavy dirs that
+# can reach gigabytes (conda/, singularity/, shadow/, source_cache/) and the
+# process-specific locks/ (restoring which would make a resumed run refuse to
+# start).
+_METADATA_INCLUDE = {"metadata", "incomplete"}
+
+
+def _parse_s3_uri(uri: str) -> Tuple[str, str]:
+    """Split ``s3://bucket/key/prefix`` into ``(bucket, key_prefix)``."""
+    if not uri.startswith("s3://"):
+        raise ValueError(f"not an s3:// URI: {uri}")
+    without_scheme = uri[len("s3://") :]
+    bucket, _, key = without_scheme.partition("/")
+    return bucket, key.rstrip("/")
+
+
+def _run_command(inner_command: Sequence[str], log_path: Path) -> int:
+    """Run the inner command, teeing combined output to console and ``log_path``.
+
+    Returns the child's exit code. A SIGTERM to this wrapper is forwarded to the
+    child so the ``finally`` upload in :func:`run` still executes.
+    """
+    with open(log_path, "w") as log_file:
+        process = subprocess.Popen(
+            list(inner_command),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+
+        def _forward_term(signum, frame):
+            process.terminate()
+
+        previous_handler = signal.signal(signal.SIGTERM, _forward_term)
+        try:
+            assert process.stdout is not None
+            for line in process.stdout:
+                sys.stdout.write(line)
+                sys.stdout.flush()
+                log_file.write(line)
+                log_file.flush()
+            return process.wait()
+        finally:
+            signal.signal(signal.SIGTERM, previous_handler)
+
+
+def _upload_file(s3, local: Path, bucket: str, key: str) -> None:
+    s3.upload_file(str(local), bucket, key)
+
+
+def _sync_metadata(s3, snakemake_dir: Path, bucket: str, key_prefix: str) -> None:
+    """Upload the resume-relevant ``.snakemake/`` subdirs under ``key_prefix``.
+
+    Walks only the allowlisted subdirs, so the potentially GB-scale
+    ``conda/``/``singularity/``/``shadow/`` trees are never traversed.
+    """
+    for subdir in _METADATA_INCLUDE:
+        root = snakemake_dir / subdir
+        if not root.is_dir():
+            continue
+        for path in root.rglob("*"):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(snakemake_dir)
+            key = f"{key_prefix}/{rel.as_posix()}"
+            try:
+                _upload_file(s3, path, bucket, key)
+            except Exception as e:  # one bad file must not abort the sync
+                print(
+                    f"coordinator-runner: failed to upload {rel}: {e}", file=sys.stderr
+                )
+
+
+def _persist_artifacts(
+    boto3_module,
+    bucket: str,
+    run_key: str,
+    job_id: str,
+    exit_code: int,
+    log_path: Path,
+    snakemake_dir: Path,
+) -> None:
+    """Best-effort upload of the driver log, resume metadata, and a status.json."""
+    try:
+        s3 = boto3_module.client("s3")
+        if log_path.exists():
+            _upload_file(s3, log_path, bucket, f"{run_key}/coordinator.log")
+        _sync_metadata(s3, snakemake_dir, bucket, f"{run_key}/snakemake")
+        status = {"job_id": job_id, "exit_code": exit_code, "succeeded": exit_code == 0}
+        s3.put_object(
+            Bucket=bucket,
+            Key=f"{run_key}/status.json",
+            Body=json.dumps(status).encode(),
+        )
+    except Exception as e:  # never mask the workflow's own exit code
+        print(f"coordinator-runner: failed to persist artifacts: {e}", file=sys.stderr)
+
+
+def _notify(
+    boto3_module, sns_topic_arn: str, job_id: str, exit_code: int, status_s3_prefix: str
+) -> None:
+    """Best-effort SNS notification of the coordinator's outcome."""
+    try:
+        outcome = "succeeded" if exit_code == 0 else "FAILED"
+        boto3_module.client("sns").publish(
+            TopicArn=sns_topic_arn,
+            Subject=f"Snakemake coordinator {job_id} {outcome}",
+            Message=(
+                f"Coordinator job {job_id} {outcome} (exit code {exit_code}).\n"
+                f"Artifacts: {status_s3_prefix.rstrip('/')}/{job_id}/"
+            ),
+        )
+    except Exception as e:
+        print(
+            f"coordinator-runner: failed to publish notification: {e}", file=sys.stderr
+        )
+
+
+def run(
+    inner_command: Sequence[str],
+    *,
+    status_s3_prefix: str,
+    sns_topic_arn: Optional[str] = None,
+    workdir: Optional[Path] = None,
+    boto3_module=None,
+) -> int:
+    """Run the coordinator command and persist log + metadata (+ notify) on exit.
+
+    ``status_s3_prefix`` is an ``s3://`` base; artifacts land under
+    ``<prefix>/<AWS_BATCH_JOB_ID>/``. Returns the inner command's exit code.
+    ``boto3_module`` is injectable for testing.
+    """
+    if boto3_module is None:
+        import boto3 as boto3_module  # local import: only needed at runtime
+
+    directory = workdir or Path.cwd()
+    job_id = os.environ.get("AWS_BATCH_JOB_ID", "unknown")
+    bucket, base_key = _parse_s3_uri(status_s3_prefix)
+    run_key = f"{base_key}/{job_id}" if base_key else job_id
+    log_path = directory / "coordinator.log"
+
+    exit_code = 1
+    try:
+        exit_code = _run_command(inner_command, log_path)
+        return exit_code
+    finally:
+        _persist_artifacts(
+            boto3_module,
+            bucket,
+            run_key,
+            job_id,
+            exit_code,
+            log_path,
+            directory / ".snakemake",
+        )
+        if sns_topic_arn:
+            _notify(boto3_module, sns_topic_arn, job_id, exit_code, status_s3_prefix)
+
+
+def _parse_args(argv: Sequence[str]) -> Tuple[argparse.Namespace, List[str]]:
+    parser = argparse.ArgumentParser(
+        prog="snakemake-aws-batch-coordinator-runner",
+        description="Run the coordinator's Snakemake command and persist its log "
+        "and metadata to S3 on exit. Pass the command after `--`.",
+    )
+    parser.add_argument("--status-s3-prefix", required=True)
+    parser.add_argument("--sns-topic-arn", default=None)
+    parser.add_argument("inner_command", nargs=argparse.REMAINDER)
+    ns = parser.parse_args(argv)
+    return ns, strip_remainder_separator(ns.inner_command)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ns, inner = _parse_args(sys.argv[1:] if argv is None else argv)
+    if not inner:
+        print("coordinator-runner: no command given after `--`", file=sys.stderr)
+        return 2
+    return run(
+        inner,
+        status_s3_prefix=ns.status_s3_prefix,
+        sns_topic_arn=ns.sns_topic_arn,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,238 @@
+"""Unit tests for the AWS Batch coordinator launcher.
+
+These cover command construction, wrapper-workflow generation, queue routing,
+argument parsing, and that ``launch`` invokes the submission and cleans up the
+generated wrapper. They do not touch AWS; the end-to-end "immediate-submit
+submits one job and exits" behavior is covered separately by the moto-backed
+integration test.
+"""
+
+import shlex
+from pathlib import Path
+
+from snakemake_executor_plugin_aws_batch.coordinator import (
+    COORDINATOR_RULE,
+    WRAPPER_SNAKEFILE_NAME,
+    CoordinatorConfig,
+    _inner_command_parts,
+    _parse_args,
+    _real_snakefile,
+    build_coordinator_command,
+    build_outer_command,
+    launch,
+    write_wrapper_snakefile,
+)
+
+
+def _inner_command(config: CoordinatorConfig, workflow_args) -> str:
+    """Shell-quoted inner command — the argv the coordinator runs in-cloud."""
+    return shlex.join(_inner_command_parts(config, workflow_args))
+
+
+WORKER_QUEUE = "arn:aws:batch:us-east-1:1:job-queue/workers"
+COORD_QUEUE = "arn:aws:batch:us-east-1:1:job-queue/coordinator-ondemand"
+ROLE = "arn:aws:iam::1:role/job-role"
+
+
+def _config(**overrides) -> CoordinatorConfig:
+    base = dict(
+        region="us-east-1",
+        job_queue=WORKER_QUEUE,
+        job_role=ROLE,
+        default_storage_provider="s3",
+        default_storage_prefix="s3://bucket/prefix",
+    )
+    base.update(overrides)
+    return CoordinatorConfig(**base)
+
+
+class TestInnerCommand:
+    def test_inner_uses_worker_queue_and_workflow_args(self):
+        cmd = _inner_command(
+            _config(coordinator_queue=COORD_QUEUE), ["-s", "Snakefile", "all"]
+        )
+        assert cmd.startswith("snakemake ")
+        assert "--executor aws-batch" in cmd
+        # The inner (in-cloud) run submits workers to the WORKER queue.
+        assert WORKER_QUEUE in cmd
+        assert COORD_QUEUE not in cmd
+        assert "--default-storage-provider s3" in cmd
+        assert cmd.rstrip().endswith("Snakefile all")
+
+    def test_inner_includes_container_image_when_set(self):
+        cmd = _inner_command(_config(container_image="img:1"), ["all"])
+        assert "--aws-batch-container-image img:1" in cmd
+
+
+class TestCoordinatorCommand:
+    def test_wraps_inner_with_runner_and_default_status_prefix(self):
+        cmd = build_coordinator_command(_config(), ["-s", "Snakefile", "all"])
+        assert "snakemake_executor_plugin_aws_batch.coordinator_runner" in cmd
+        # Default status prefix derives from the storage prefix.
+        assert "--status-s3-prefix s3://bucket/prefix/.coordinator" in cmd
+        # The real workflow command follows the runner's `--` separator.
+        assert " -- snakemake " in cmd
+        assert cmd.rstrip().endswith("Snakefile all")
+
+    def test_includes_sns_topic_when_set(self):
+        cmd = build_coordinator_command(
+            _config(notify_sns_topic="arn:aws:sns:us-east-1:1:topic"), ["all"]
+        )
+        assert "--sns-topic-arn arn:aws:sns:us-east-1:1:topic" in cmd
+
+    def test_custom_status_prefix_overrides_default(self):
+        cmd = build_coordinator_command(
+            _config(status_s3_prefix="s3://other/coord"), ["all"]
+        )
+        assert "--status-s3-prefix s3://other/coord" in cmd
+        assert "/.coordinator" not in cmd
+
+
+class TestOuterCommand:
+    def test_outer_is_immediate_submit_notemp_on_coordinator_rule(self):
+        outer = build_outer_command(_config(), Path("/tmp/w.smk"))
+        assert "--immediate-submit" in outer
+        assert "--notemp" in outer
+        assert outer[-1] == COORDINATOR_RULE
+        assert "--snakefile" in outer and "/tmp/w.smk" in outer
+
+    def test_outer_targets_coordinator_queue_when_set(self):
+        outer = build_outer_command(
+            _config(coordinator_queue=COORD_QUEUE), Path("/tmp/w.smk")
+        )
+        # The coordinator JOB itself goes to the on-demand coordinator queue.
+        assert COORD_QUEUE in outer
+        assert WORKER_QUEUE not in outer
+
+    def test_outer_defaults_coordinator_queue_to_worker_queue(self):
+        outer = build_outer_command(_config(), Path("/tmp/w.smk"))
+        assert WORKER_QUEUE in outer
+
+
+class TestRealSnakefile:
+    def test_extracts_dash_s(self):
+        assert _real_snakefile(["-s", "wf/Snakefile", "all"]) == "wf/Snakefile"
+
+    def test_extracts_long_flag_and_equals(self):
+        assert _real_snakefile(["--snakefile", "A.smk"]) == "A.smk"
+        assert _real_snakefile(["--snakefile=B.smk", "all"]) == "B.smk"
+        assert _real_snakefile(["-sC.smk"]) == "C.smk"
+
+    def test_resolves_default_from_directory(self, tmp_path: Path):
+        (tmp_path / "workflow").mkdir()
+        (tmp_path / "workflow" / "Snakefile").write_text("")
+        assert _real_snakefile(["all"], tmp_path) == "workflow/Snakefile"
+
+    def test_defaults_to_snakefile_when_none_exist(self, tmp_path: Path):
+        result = _real_snakefile(["all", "--configfile", "c.yaml"], tmp_path)
+        assert result == "Snakefile"
+
+
+class TestWrapperSnakefile:
+    def test_includes_real_workflow_and_no_output_rule(self, tmp_path: Path):
+        cmd = build_coordinator_command(_config(), ["-s", "Snakefile", "all"])
+        path = write_wrapper_snakefile(cmd, tmp_path, "wf/Snakefile")
+        assert path.name == WRAPPER_SNAKEFILE_NAME
+        text = path.read_text()
+        assert f"rule {COORDINATOR_RULE}:" in text
+        # The real workflow is included so its sources deploy with the coordinator.
+        assert "include: 'wf/Snakefile'" in text or 'include: "wf/Snakefile"' in text
+        # No output directive -> nothing for Snakemake to verify on the async job.
+        assert "output:" not in text
+        assert "shell:" in text
+
+    def test_braces_in_command_are_escaped_for_shell_directive(self, tmp_path: Path):
+        # Snakemake brace-formats `shell:` strings, so a literal `{`/`}` from a
+        # user --config value must be doubled in the wrapper or it raises at
+        # rule-execution time. Route a braced arg through the real builder.
+        cmd = build_coordinator_command(_config(), ["--config", "x={a}", "all"])
+        assert "{a}" in cmd  # the un-escaped inner command still has a single brace
+        path = write_wrapper_snakefile(cmd, tmp_path, "wf/Snakefile")
+        text = path.read_text()
+        # The shell directive must contain the doubled form, and no lone brace
+        # that Snakemake would try to interpolate.
+        assert "{{a}}" in text
+
+
+class TestLaunch:
+    def test_launch_runs_outer_command_and_cleans_up(self, tmp_path: Path):
+        calls = {}
+
+        def fake_runner(cmd, **kwargs):
+            calls["cmd"] = cmd
+            wrapper = tmp_path / WRAPPER_SNAKEFILE_NAME
+            # The wrapper must still exist while the submission runs...
+            calls["wrapper_present_during_run"] = wrapper.exists()
+            # ...and it must invoke the in-job runner around the real command.
+            calls["wrapper_text"] = wrapper.read_text()
+
+            class R:
+                returncode = 0
+
+            return R()
+
+        rc = launch(_config(), ["all"], project_dir=tmp_path, runner=fake_runner)
+        assert rc == 0
+        assert calls["cmd"][0] == "snakemake"
+        assert "--immediate-submit" in calls["cmd"]
+        assert calls["wrapper_present_during_run"] is True
+        assert "coordinator_runner" in calls["wrapper_text"]
+        # Wrapper is removed after submission.
+        assert not (tmp_path / WRAPPER_SNAKEFILE_NAME).exists()
+
+    def test_launch_propagates_nonzero_exit(self, tmp_path: Path):
+        def failing_runner(cmd, **kwargs):
+            class R:
+                returncode = 2
+
+            return R()
+
+        rc = launch(_config(), ["all"], project_dir=tmp_path, runner=failing_runner)
+        assert rc == 2
+        assert not (tmp_path / WRAPPER_SNAKEFILE_NAME).exists()
+
+
+class TestParseArgs:
+    def test_workflow_args_after_double_dash(self):
+        config, workflow_args = _parse_args(
+            [
+                "--aws-batch-region",
+                "us-east-1",
+                "--aws-batch-job-queue",
+                WORKER_QUEUE,
+                "--aws-batch-job-role",
+                ROLE,
+                "--default-storage-provider",
+                "s3",
+                "--default-storage-prefix",
+                "s3://bucket/prefix",
+                "--",
+                "-s",
+                "Snakefile",
+                "all",
+            ]
+        )
+        assert config.region == "us-east-1"
+        assert config.job_queue == WORKER_QUEUE
+        assert workflow_args == ["-s", "Snakefile", "all"]
+
+    def test_coordinator_queue_optional(self):
+        config, _ = _parse_args(
+            [
+                "--aws-batch-region",
+                "us-east-1",
+                "--aws-batch-job-queue",
+                WORKER_QUEUE,
+                "--aws-batch-job-role",
+                ROLE,
+                "--aws-batch-coordinator-queue",
+                COORD_QUEUE,
+                "--default-storage-provider",
+                "s3",
+                "--default-storage-prefix",
+                "s3://bucket/prefix",
+                "--",
+                "all",
+            ]
+        )
+        assert config.coordinator_queue == COORD_QUEUE

--- a/tests/test_coordinator_integration.py
+++ b/tests/test_coordinator_integration.py
@@ -1,0 +1,128 @@
+"""End-to-end check that the coordinator mechanism actually submits one Batch
+job and exits WITHOUT polling.
+
+This exercises the exact native path the launcher relies on: a no-output wrapper
+rule run with ``--executor aws-batch --immediate-submit --notemp``. AWS is fully
+mocked — S3 via moto (default storage + source deployment), Batch via a stub
+BatchClient — so it runs offline. Skipped if moto is not installed.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+moto = pytest.importorskip("moto")
+import boto3  # noqa: E402
+
+from snakemake_executor_plugin_aws_batch.coordinator import (  # noqa: E402
+    COORDINATOR_RULE,
+    build_coordinator_command,
+    write_wrapper_snakefile,
+)
+
+BUCKET = "coordinator-it-bucket"
+
+
+def _stub_batch_client(calls):
+    client = MagicMock(name="BatchClient")
+    client.register_job_definition.side_effect = lambda **kw: (
+        calls.__setitem__("register", calls["register"] + 1)
+        or {
+            "jobDefinitionName": kw.get("jobDefinitionName", "jd"),
+            "revision": 1,
+            "jobDefinitionArn": "arn:aws:batch:us-east-1:0:job-definition/jd:1",
+        }
+    )
+    client.submit_job.side_effect = lambda **kw: (
+        calls.__setitem__("submit", calls["submit"] + 1)
+        or {"jobName": kw.get("jobName", "j"), "jobId": "job-1", "jobQueue": "q"}
+    )
+    client.describe_jobs.side_effect = lambda **kw: (
+        calls.__setitem__("describe", calls["describe"] + 1) or {"jobs": []}
+    )
+    client.deregister_job_definition.return_value = {}
+    client.terminate_job.return_value = {}
+    return client
+
+
+@moto.mock_aws
+def test_immediate_submit_submits_once_and_does_not_poll():
+    os.environ.update(
+        AWS_DEFAULT_REGION="us-east-1",
+        AWS_ACCESS_KEY_ID="testing",
+        AWS_SECRET_ACCESS_KEY="testing",
+    )
+    boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=BUCKET)
+
+    from snakemake_executor_plugin_aws_batch.coordinator import CoordinatorConfig
+
+    config = CoordinatorConfig(
+        region="us-east-1",
+        job_queue="arn:aws:batch:us-east-1:0:job-queue/workers",
+        job_role="arn:aws:iam::0:role/r",
+        default_storage_provider="s3",
+        default_storage_prefix=f"s3://{BUCKET}/prefix",
+    )
+
+    workdir = Path(tempfile.mkdtemp(prefix="coord-it-"))
+    # The wrapper `include:`s a real workflow, so it must exist and parse. The
+    # coordinator job is mocked and never runs, so a trivial rule suffices; we
+    # only verify the OUTER immediate-submit behavior.
+    (workdir / "Snakefile").write_text("rule real_all:\n    shell: 'echo hi'\n")
+    cmd = build_coordinator_command(config, ["-s", "Snakefile", "real_all"])
+    wrapper = write_wrapper_snakefile(cmd, workdir, "Snakefile")
+    os.chdir(workdir)
+
+    from snakemake.api import SnakemakeApi
+    from snakemake.settings.types import (
+        DAGSettings,
+        ExecutionSettings,
+        RemoteExecutionSettings,
+        ResourceSettings,
+        StorageSettings,
+    )
+    from snakemake_executor_plugin_aws_batch import ExecutorSettings
+    import snakemake_executor_plugin_aws_batch as plugin
+    import snakemake_executor_plugin_aws_batch.batch_job_builder as bjb
+
+    calls = {"register": 0, "submit": 0, "describe": 0}
+    stub = _stub_batch_client(calls)
+
+    with patch.object(plugin, "BatchClient", return_value=stub), patch.object(
+        bjb, "BatchClient", return_value=stub
+    ), patch.object(
+        bjb.BatchJobBuilder, "_get_platform_from_queue", return_value="EC2"
+    ):
+        with SnakemakeApi() as api:
+            wf = api.workflow(
+                resource_settings=ResourceSettings(nodes=1),
+                storage_settings=StorageSettings(
+                    default_storage_provider="s3",
+                    default_storage_prefix=f"s3://{BUCKET}/prefix",
+                    notemp=True,
+                ),
+                snakefile=wrapper,
+                workdir=workdir,
+            )
+            dag = wf.dag(dag_settings=DAGSettings(targets={COORDINATOR_RULE}))
+            dag.execute_workflow(
+                executor="aws-batch",
+                execution_settings=ExecutionSettings(),
+                remote_execution_settings=RemoteExecutionSettings(
+                    immediate_submit=True,
+                    seconds_between_status_checks=1,
+                ),
+                executor_settings=ExecutorSettings(
+                    region="us-east-1",
+                    job_queue=config.job_queue,
+                    job_role=config.job_role,
+                ),
+            )
+
+    # The coordinator job was submitted exactly once...
+    assert calls["submit"] == 1
+    # ...and immediate-submit did NOT enter a status-polling loop.
+    assert calls["describe"] == 0

--- a/tests/test_coordinator_runner.py
+++ b/tests/test_coordinator_runner.py
@@ -1,0 +1,201 @@
+"""Unit tests for the in-coordinator runner (log/metadata persistence + notify)."""
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from snakemake_executor_plugin_aws_batch.coordinator_runner import (
+    _parse_args,
+    _parse_s3_uri,
+    _sync_metadata,
+    run,
+)
+
+
+class FakeBoto3:
+    """Stand-in boto3 module: `.client("s3"|"sns")` returns per-service mocks."""
+
+    def __init__(self):
+        self.s3 = MagicMock(name="s3")
+        self.sns = MagicMock(name="sns")
+
+    def client(self, service, **kwargs):
+        return {"s3": self.s3, "sns": self.sns}[service]
+
+
+def test_parse_s3_uri_splits_bucket_and_key():
+    assert _parse_s3_uri("s3://bucket/a/b") == ("bucket", "a/b")
+    assert _parse_s3_uri("s3://bucket") == ("bucket", "")
+
+
+def test_run_uploads_log_and_status_and_returns_exit_code(tmp_path, monkeypatch):
+    monkeypatch.setenv("AWS_BATCH_JOB_ID", "job-42")
+    fake = FakeBoto3()
+    rc = run(
+        [sys.executable, "-c", "print('hello from coordinator')"],
+        status_s3_prefix="s3://bucket/base",
+        workdir=tmp_path,
+        boto3_module=fake,
+    )
+    assert rc == 0
+    # Log file was produced and uploaded under the per-job key.
+    assert (tmp_path / "coordinator.log").exists()
+    log_keys = [c.args[2] for c in fake.s3.upload_file.call_args_list]
+    assert "base/job-42/coordinator.log" in log_keys
+    # A status.json recording success was written.
+    status_call = fake.s3.put_object.call_args
+    assert status_call.kwargs["Key"] == "base/job-42/status.json"
+    assert b'"succeeded": true' in status_call.kwargs["Body"]
+
+
+def test_run_reports_failure_exit_code(tmp_path, monkeypatch):
+    monkeypatch.setenv("AWS_BATCH_JOB_ID", "job-9")
+    fake = FakeBoto3()
+    rc = run(
+        [sys.executable, "-c", "import sys; sys.exit(3)"],
+        status_s3_prefix="s3://bucket/base",
+        workdir=tmp_path,
+        boto3_module=fake,
+    )
+    assert rc == 3
+    assert b'"succeeded": false' in fake.s3.put_object.call_args.kwargs["Body"]
+
+
+def test_run_publishes_notification_when_topic_set(tmp_path, monkeypatch):
+    monkeypatch.setenv("AWS_BATCH_JOB_ID", "job-1")
+    fake = FakeBoto3()
+    run(
+        [sys.executable, "-c", "pass"],
+        status_s3_prefix="s3://bucket/base",
+        sns_topic_arn="arn:aws:sns:us-east-1:1:topic",
+        workdir=tmp_path,
+        boto3_module=fake,
+    )
+    assert fake.sns.publish.called
+    topic = fake.sns.publish.call_args.kwargs["TopicArn"]
+    assert topic == "arn:aws:sns:us-east-1:1:topic"
+
+
+def test_run_does_not_notify_without_topic(tmp_path, monkeypatch):
+    monkeypatch.setenv("AWS_BATCH_JOB_ID", "job-1")
+    fake = FakeBoto3()
+    run(
+        [sys.executable, "-c", "pass"],
+        status_s3_prefix="s3://bucket/base",
+        workdir=tmp_path,
+        boto3_module=fake,
+    )
+    assert not fake.sns.publish.called
+
+
+def test_sync_metadata_uploads_only_resume_relevant_dirs(tmp_path):
+    snakemake_dir = tmp_path / ".snakemake"
+    for sub, name in [
+        ("metadata", "m1"),
+        ("incomplete", "i1"),
+        ("locks", "l1"),  # process-specific — must be skipped
+        ("conda", "big"),  # heavy cache — must be skipped
+        ("shadow", "s1"),  # heavy — must be skipped
+    ]:
+        (snakemake_dir / sub).mkdir(parents=True)
+        (snakemake_dir / sub / name).write_text("x")
+    s3 = MagicMock()
+    _sync_metadata(s3, snakemake_dir, "bucket", "prefix")
+    uploaded_keys = [c.args[2] for c in s3.upload_file.call_args_list]
+    assert "prefix/metadata/m1" in uploaded_keys
+    assert "prefix/incomplete/i1" in uploaded_keys
+    for skipped in ("locks", "conda", "shadow"):
+        assert not any(skipped in k for k in uploaded_keys)
+
+
+def test_parse_args_inner_command_after_double_dash():
+    ns, inner = _parse_args(
+        ["--status-s3-prefix", "s3://b/p", "--", "snakemake", "-s", "Snakefile"]
+    )
+    assert ns.status_s3_prefix == "s3://b/p"
+    assert inner == ["snakemake", "-s", "Snakefile"]
+
+
+# Helper run in a child process: it invokes run() with a long-sleeping inner
+# command that first records its own PID, so the parent test can SIGTERM the
+# wrapper and confirm the inner child was terminated rather than orphaned.
+_SIGTERM_HELPER = """
+import os, sys, time
+from pathlib import Path
+from unittest.mock import MagicMock
+from snakemake_executor_plugin_aws_batch.coordinator_runner import run
+
+pidfile, workdir, rcfile = sys.argv[1], sys.argv[2], sys.argv[3]
+os.environ["AWS_BATCH_JOB_ID"] = "sigterm-test"
+inner = [
+    sys.executable, "-c",
+    "import os,sys,time;"
+    "open(sys.argv[1],'w').write(str(os.getpid()));"
+    "time.sleep(120)",
+    pidfile,
+]
+print("READY", flush=True)
+rc = run(inner, status_s3_prefix="s3://b/p", workdir=Path(workdir),
+         boto3_module=MagicMock())
+Path(rcfile).write_text(str(rc))
+"""
+
+
+def _wait_until(predicate, timeout, interval=0.05):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+def _process_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+@pytest.mark.skipif(
+    os.name != "posix", reason="SIGTERM forwarding is a POSIX-signal behavior"
+)
+def test_run_command_forwards_sigterm_to_child(tmp_path):
+    pidfile = tmp_path / "child.pid"
+    rcfile = tmp_path / "rc.txt"
+    helper = tmp_path / "sigterm_helper.py"
+    helper.write_text(_SIGTERM_HELPER)
+
+    proc = subprocess.Popen(
+        [sys.executable, str(helper), str(pidfile), str(tmp_path), str(rcfile)],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert proc.stdout is not None
+        assert proc.stdout.readline().strip() == "READY"
+        # Wait for the inner child to record its PID.
+        assert _wait_until(lambda: pidfile.exists(), timeout=15), "child never started"
+        child_pid = int(pidfile.read_text())
+
+        # SIGTERM the wrapper; _forward_term must terminate the inner child.
+        proc.send_signal(signal.SIGTERM)
+        proc.wait(timeout=15)
+
+        # A broken forward would orphan the inner child (still sleeping 120s);
+        # a working forward terminates and reaps it.
+        assert _wait_until(
+            lambda: not _process_alive(child_pid), timeout=10
+        ), "inner child was orphaned — SIGTERM was not forwarded"
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+        proc.stdout.close()


### PR DESCRIPTION
> **Draft for design discussion.** Opt-in coordinator mode — run the workflow *driver* as an AWS Batch job.

## What

An **opt-in** launcher, `snakemake-aws-batch-coordinator`, that submits the Snakemake *driver itself* as one Batch job and exits — freeing the local terminal — while the workflow runs in the cloud with the **full** Snakemake feature set (checkpoints, temp handling, live scheduling/retries). Default behavior is unchanged; you opt in by invoking the launcher instead of `snakemake`.

```bash
snakemake-aws-batch-coordinator \
  --aws-batch-region … --aws-batch-job-queue …/workers \
  --aws-batch-job-role … --aws-batch-coordinator-queue …/coordinator-ondemand \
  --default-storage-provider s3 --default-storage-prefix s3://… \
  -- -s Snakefile my_target
```

## How (native Snakemake — no scheduler hijack, no `os._exit`)

The launcher writes a wrapper workflow that `include:`s your real workflow (so Snakemake discovers and deploys its sources — snakefiles **and** scripts — with the coordinator job) and defines a single **no-output** rule whose command runs your real invocation in the cloud. It runs that wrapper with `--immediate-submit --notemp`, targeting only the no-output rule: Snakemake **natively** submits the one job and exits without polling, and the no-output rule means no output-verification on the fire-and-forget job. The coordinator job pulls the deployed sources (`job_deploy_sources`) and runs the real workflow.

I verified this end-to-end against the plugin (S3 mocked via moto, Batch stubbed): the coordinator is **submitted exactly once, never polled, clean exit** — covered by an integration test.

## In-job durability + observability (`coordinator_runner`)

The coordinator job runs Snakemake through an in-job wrapper that, on exit, uploads the driver log and the resume-relevant `.snakemake/` state (`metadata/` + `incomplete/`; heavy caches and `locks/` skipped) to a per-run S3 prefix, and — if `--aws-batch-coordinator-notify-sns-topic` is set — publishes an SNS notification with the outcome. Because the wrapper is the *parent* process, it survives an inner-Snakemake crash/OOM and still records the result; only an instance-level failure escapes it.

## Semantics & limitations (discussion points)

- **The local exit code means "coordinator submitted", not "workflow succeeded"** — inherent to fire-and-forget; don't gate CI on it. Track the outcome via the coordinator's Batch job status / the S3 `status.json` / the SNS notification.
- **Logs:** the coordinator's Snakemake output streams to CloudWatch automatically (Batch default); the in-job wrapper additionally persists a durable copy to S3.
- **Run the coordinator on on-demand** (`--aws-batch-coordinator-queue`). Workers can be Spot — the coordinator resubmits them on interruption — but a Spot reclaim of the *coordinator* tears down the driver. Prefer Batch `attempts=1` for the coordinator so a failure surfaces rather than silently re-running with amnesia.
- The coordinator image must have `python` + `snakemake` (with this plugin) on `PATH` — the project's published runtime image satisfies this. `include:`-ing your workflow means its top-level code (e.g. `configfile:`) is evaluated locally at submit time, so run the launcher from the workflow directory as you would `snakemake`.

## Open questions for maintainers

1. Is an opt-in **launcher / console-script** the right surface? (A `--aws-batch-coordinator` flag on `snakemake` was considered and rejected — a flag is only seen after the scheduler starts, which forces an `os._exit` hijack.)
2. Should the in-job **durability/notification wrapper** stay part of this, or split out?
3. The coordinator is designed to sit alongside the runtime-image work; happy to align the two.

Marked draft to settle the design before polishing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in coordinator mode for running Snakemake workflows on AWS Batch after the local submission completes.
  * Added persistence of coordinator logs, workflow metadata, and status in Amazon S3.
  * Added optional SNS notifications, workflow restoration, configurable queues, container images, and status locations.

* **Documentation**
  * Documented coordinator setup, configuration, monitoring, recovery, notifications, and capacity guidance.

* **Tests**
  * Added comprehensive coverage for coordinator submission, execution, persistence, restoration, notifications, and argument handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->