### PR TITLE
fix: sanitize job names for AWS Batch compatibility

### DIFF
--- a/snakemake_executor_plugin_aws_batch/batch_job_builder.py
+++ b/snakemake_executor_plugin_aws_batch/batch_job_builder.py
@@ -111,6 +111,18 @@ class BatchJobBuilder:
         """
         return ["/bin/bash", "-c", remote_command]
 
+    def _build_job_names(self) -> tuple[str, str]:
+        """Build sanitized job name and job definition name.
+
+        Returns:
+            A tuple of (job_name, job_definition_name) suitable for AWS Batch.
+        """
+        job_uuid = str(uuid.uuid4())
+        sanitized_name = _sanitize_job_name(self.job.name)
+        job_name = f"snakejob-{sanitized_name}-{job_uuid}"
+        job_definition_name = f"snakejob-def-{sanitized_name}-{job_uuid}"
+        return job_name, job_definition_name
+
     def _get_platform_from_queue(self) -> str:
         """
         Determine the platform (EC2 or FARGATE) from the job queue's
@@ -255,10 +267,7 @@ class BatchJobBuilder:
                 f"Use an EC2-backed AWS Batch queue instead."
             )
 
-        job_uuid = str(uuid.uuid4())
-        sanitized_name = _sanitize_job_name(self.job.name)
-        job_name = f"snakejob-{sanitized_name}-{job_uuid}"
-        job_definition_name = f"snakejob-def-{sanitized_name}-{job_uuid}"
+        job_name, job_definition_name = self._build_job_names()
 
         # Validate and convert resources
         gpu = max(0, int(self.job.resources.get("_gpus", 0)))
@@ -528,9 +537,7 @@ class BatchJobBuilder:
         """
         self._validate_preexisting_compatibility()
 
-        job_uuid = str(uuid.uuid4())
-        sanitized_name = _sanitize_job_name(self.job.name)
-        job_name = f"snakejob-{sanitized_name}-{job_uuid}"
+        job_name, _ = self._build_job_names()
 
         gpu = max(0, int(self.job.resources.get("_gpus", 0)))
         vcpu = max(

--- a/snakemake_executor_plugin_aws_batch/batch_job_builder.py
+++ b/snakemake_executor_plugin_aws_batch/batch_job_builder.py
@@ -18,10 +18,11 @@ SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR = "SNAKEMAKE_AWS_BATCH_JOB_TAGS"
 # AWS Batch name constraints
 # Job names and job definition names must be <= 128 characters
 # Valid characters: letters, numbers, hyphens, and underscores
-AWS_BATCH_MAX_NAME_LENGTH = 128
-# UUID (36) + "snakejob-def-" (13) + "-" (1) = 50 chars overhead for job def name
-# Use 78 as max rule name length to accommodate both job and job def names
-MAX_RULE_NAME_LENGTH = 78
+  AWS_BATCH_MAX_NAME_LENGTH: int = 128
+  # UUID (36) + "snakejob-def-" (13) + "-" (1) = 50 chars overhead for job def name
+  _JOB_DEF_NAME_OVERHEAD: int = 50
+  # Max rule name length accommodates both job and job def names
+  MAX_RULE_NAME_LENGTH: int = AWS_BATCH_MAX_NAME_LENGTH - _JOB_DEF_NAME_OVERHEAD
 # Suffix to indicate name was truncated (2 chars)
 TRUNCATION_SUFFIX = "-x"
 

--- a/snakemake_executor_plugin_aws_batch/batch_job_builder.py
+++ b/snakemake_executor_plugin_aws_batch/batch_job_builder.py
@@ -1,4 +1,5 @@
 import os
+import re
 import uuid
 from typing import Any, List, Optional
 from botocore.exceptions import ClientError
@@ -13,6 +14,46 @@ from snakemake_executor_plugin_aws_batch.constant import (
 )
 
 SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR = "SNAKEMAKE_AWS_BATCH_JOB_TAGS"
+
+# AWS Batch name constraints
+# Job names and job definition names must be <= 128 characters
+# Valid characters: letters, numbers, hyphens, and underscores
+AWS_BATCH_MAX_NAME_LENGTH = 128
+# UUID (36) + "snakejob-def-" (13) + "-" (1) = 50 chars overhead for job def name
+# Use 78 as max rule name length to accommodate both job and job def names
+MAX_RULE_NAME_LENGTH = 78
+# Suffix to indicate name was truncated (2 chars)
+TRUNCATION_SUFFIX = "-x"
+
+
+def _sanitize_job_name(name: str, max_length: int = MAX_RULE_NAME_LENGTH) -> str:
+    """Sanitize a job name for AWS Batch compatibility.
+
+    AWS Batch job names must:
+    - Be <= 128 characters total
+    - Contain only alphanumeric characters, hyphens, and underscores
+
+    When names exceed max_length, they are truncated and suffixed with "-x"
+    to indicate truncation occurred.
+
+    Args:
+        name: The raw job/rule name from Snakemake
+        max_length: Maximum length for the sanitized name portion
+
+    Returns:
+        Sanitized name safe for AWS Batch
+    """
+    # Replace invalid characters with underscores
+    sanitized = re.sub(r"[^a-zA-Z0-9_-]", "_", name)
+    # Collapse multiple underscores
+    sanitized = re.sub(r"_+", "_", sanitized)
+    # Strip leading/trailing underscores or hyphens
+    sanitized = sanitized.strip("_-")
+    # Truncate to max length, leaving room for truncation suffix
+    if len(sanitized) > max_length:
+        truncate_at = max_length - len(TRUNCATION_SUFFIX)
+        sanitized = sanitized[:truncate_at].rstrip("_-") + TRUNCATION_SUFFIX
+    return sanitized or "job"
 
 
 class BatchJobBuilder:
@@ -213,8 +254,9 @@ class BatchJobBuilder:
             )
 
         job_uuid = str(uuid.uuid4())
-        job_name = f"snakejob-{self.job.name}-{job_uuid}"
-        job_definition_name = f"snakejob-def-{self.job.name}-{job_uuid}"
+        sanitized_name = _sanitize_job_name(self.job.name)
+        job_name = f"snakejob-{sanitized_name}-{job_uuid}"
+        job_definition_name = f"snakejob-def-{sanitized_name}-{job_uuid}"
 
         # Validate and convert resources
         gpu = max(0, int(self.job.resources.get("_gpus", 0)))
@@ -485,7 +527,8 @@ class BatchJobBuilder:
         self._validate_preexisting_compatibility()
 
         job_uuid = str(uuid.uuid4())
-        job_name = f"snakejob-{self.job.name}-{job_uuid}"
+        sanitized_name = _sanitize_job_name(self.job.name)
+        job_name = f"snakejob-{sanitized_name}-{job_uuid}"
 
         gpu = max(0, int(self.job.resources.get("_gpus", 0)))
         vcpu = max(

--- a/snakemake_executor_plugin_aws_batch/batch_job_builder.py
+++ b/snakemake_executor_plugin_aws_batch/batch_job_builder.py
@@ -45,9 +45,10 @@ def _sanitize_job_name(name: str, max_length: int = MAX_RULE_NAME_LENGTH) -> str
         Sanitized name safe for AWS Batch
     """
     # Replace invalid characters with underscores
-    sanitized = re.sub(r"[^a-zA-Z0-9_-]", "_", name)
-    # Collapse multiple underscores
-    sanitized = re.sub(r"_+", "_", sanitized)
+      # Replace runs of invalid characters (and underscores) with a single underscore
+      sanitized = re.sub(r"[^a-zA-Z0-9-]+", "_", name)
+      # Strip leading/trailing underscores or hyphens
+      sanitized = sanitized.strip("_-")
     # Strip leading/trailing underscores or hyphens
     sanitized = sanitized.strip("_-")
     # Truncate to max length, leaving room for truncation suffix

--- a/snakemake_executor_plugin_aws_batch/batch_job_builder.py
+++ b/snakemake_executor_plugin_aws_batch/batch_job_builder.py
@@ -18,13 +18,15 @@ SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR = "SNAKEMAKE_AWS_BATCH_JOB_TAGS"
 # AWS Batch name constraints
 # Job names and job definition names must be <= 128 characters
 # Valid characters: letters, numbers, hyphens, and underscores
-  AWS_BATCH_MAX_NAME_LENGTH: int = 128
-  # UUID (36) + "snakejob-def-" (13) + "-" (1) = 50 chars overhead for job def name
-  _JOB_DEF_NAME_OVERHEAD: int = 50
-  # Max rule name length accommodates both job and job def names
-  MAX_RULE_NAME_LENGTH: int = AWS_BATCH_MAX_NAME_LENGTH - _JOB_DEF_NAME_OVERHEAD
+AWS_BATCH_MAX_NAME_LENGTH: int = 128
+# UUID (36) + "snakejob-def-" (13) + "-" (1) = 50 chars overhead for job def name
+_JOB_DEF_NAME_OVERHEAD: int = 50
 # Suffix to indicate name was truncated (2 chars)
-TRUNCATION_SUFFIX = "-x"
+TRUNCATION_SUFFIX: str = "-x"
+# Max rule name length accommodates both job and job def names plus truncation suffix
+MAX_RULE_NAME_LENGTH: int = (
+    AWS_BATCH_MAX_NAME_LENGTH - _JOB_DEF_NAME_OVERHEAD - len(TRUNCATION_SUFFIX)
+)  # 76
 
 
 def _sanitize_job_name(name: str, max_length: int = MAX_RULE_NAME_LENGTH) -> str:
@@ -44,17 +46,15 @@ def _sanitize_job_name(name: str, max_length: int = MAX_RULE_NAME_LENGTH) -> str
     Returns:
         Sanitized name safe for AWS Batch
     """
-    # Replace invalid characters with underscores
-      # Replace runs of invalid characters (and underscores) with a single underscore
-      sanitized = re.sub(r"[^a-zA-Z0-9-]+", "_", name)
-      # Strip leading/trailing underscores or hyphens
-      sanitized = sanitized.strip("_-")
+    # Replace runs of invalid characters (and underscores) with a single underscore
+    sanitized = re.sub(r"[^a-zA-Z0-9-]+", "_", name)
     # Strip leading/trailing underscores or hyphens
     sanitized = sanitized.strip("_-")
-    # Truncate to max length, leaving room for truncation suffix
+    # Strip leading/trailing underscores or hyphens
+    sanitized = sanitized.strip("_-")
+    # Truncate to max length and add suffix to indicate truncation
     if len(sanitized) > max_length:
-        truncate_at = max_length - len(TRUNCATION_SUFFIX)
-        sanitized = sanitized[:truncate_at].rstrip("_-") + TRUNCATION_SUFFIX
+        sanitized = sanitized[:max_length].rstrip("_-") + TRUNCATION_SUFFIX
     return sanitized or "job"
 
 

--- a/snakemake_executor_plugin_aws_batch/batch_job_builder.py
+++ b/snakemake_executor_plugin_aws_batch/batch_job_builder.py
@@ -50,7 +50,8 @@ def _sanitize_job_name(name: str, max_length: int = MAX_RULE_NAME_LENGTH) -> str
     sanitized = sanitized.strip("_-")
     # Truncate to max length and add suffix to indicate truncation
     if len(sanitized) > max_length:
-        sanitized = sanitized[:max_length].rstrip("_-") + TRUNCATION_SUFFIX
+        truncate_at = max_length - len(TRUNCATION_SUFFIX)
+        sanitized = sanitized[:truncate_at].rstrip("_-") + TRUNCATION_SUFFIX
     return sanitized or "job"
 
 

--- a/snakemake_executor_plugin_aws_batch/batch_job_builder.py
+++ b/snakemake_executor_plugin_aws_batch/batch_job_builder.py
@@ -24,9 +24,7 @@ _JOB_DEF_NAME_OVERHEAD: int = 50
 # Suffix to indicate name was truncated (2 chars)
 TRUNCATION_SUFFIX: str = "-x"
 # Max rule name length accommodates both job and job def names plus truncation suffix
-MAX_RULE_NAME_LENGTH: int = (
-    AWS_BATCH_MAX_NAME_LENGTH - _JOB_DEF_NAME_OVERHEAD - len(TRUNCATION_SUFFIX)
-)  # 76
+MAX_RULE_NAME_LENGTH: int = AWS_BATCH_MAX_NAME_LENGTH - _JOB_DEF_NAME_OVERHEAD
 
 
 def _sanitize_job_name(name: str, max_length: int = MAX_RULE_NAME_LENGTH) -> str:

--- a/snakemake_executor_plugin_aws_batch/batch_job_builder.py
+++ b/snakemake_executor_plugin_aws_batch/batch_job_builder.py
@@ -48,8 +48,6 @@ def _sanitize_job_name(name: str, max_length: int = MAX_RULE_NAME_LENGTH) -> str
     sanitized = re.sub(r"[^a-zA-Z0-9-]+", "_", name)
     # Strip leading/trailing underscores or hyphens
     sanitized = sanitized.strip("_-")
-    # Strip leading/trailing underscores or hyphens
-    sanitized = sanitized.strip("_-")
     # Truncate to max length and add suffix to indicate truncation
     if len(sanitized) > max_length:
         sanitized = sanitized[:max_length].rstrip("_-") + TRUNCATION_SUFFIX

--- a/tests/test_batch_job_builder.py
+++ b/tests/test_batch_job_builder.py
@@ -16,6 +16,9 @@ from snakemake_interface_common.exceptions import WorkflowError
 from snakemake_executor_plugin_aws_batch.batch_job_builder import (
     SNAKEMAKE_AWS_BATCH_JOB_TAGS_ENV_VAR,
     BatchJobBuilder,
+    _sanitize_job_name,
+    MAX_RULE_NAME_LENGTH,
+    TRUNCATION_SUFFIX,
 )
 from snakemake_executor_plugin_aws_batch.constant import (
     BATCH_JOB_PLATFORM_CAPABILITIES,
@@ -1498,3 +1501,89 @@ class TestDeregisterSkipsPreexisting:
         executor = self._make_executor()
         executor._deregister_job(submitted)
         executor.batch_client.deregister_job_definition.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests for _sanitize_job_name
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeJobName:
+    """Tests for the _sanitize_job_name helper function."""
+
+    def test_simple_name_unchanged(self):
+        """Simple alphanumeric names should pass through unchanged."""
+        assert _sanitize_job_name("align") == "align"
+        assert _sanitize_job_name("my_rule") == "my_rule"
+        assert _sanitize_job_name("rule-name") == "rule-name"
+
+    def test_invalid_characters_replaced(self):
+        """Characters not allowed in AWS Batch names should be replaced."""
+        # Dots replaced with underscores
+        assert _sanitize_job_name("rule.name") == "rule_name"
+        # Colons replaced
+        assert _sanitize_job_name("rule:name") == "rule_name"
+        # Multiple invalid chars
+        assert _sanitize_job_name("a.b:c/d") == "a_b_c_d"
+
+    def test_multiple_underscores_collapsed(self):
+        """Multiple consecutive underscores should be collapsed to one."""
+        assert _sanitize_job_name("rule__name") == "rule_name"
+        assert _sanitize_job_name("a...b") == "a_b"
+
+    def test_leading_trailing_stripped(self):
+        """Leading and trailing underscores/hyphens should be stripped."""
+        assert _sanitize_job_name("_rule_") == "rule"
+        assert _sanitize_job_name("-rule-") == "rule"
+        assert _sanitize_job_name("__rule__") == "rule"
+
+    def test_truncation_at_max_length(self):
+        """Names exceeding max length should be truncated with suffix."""
+        long_name = "a" * 100
+        result = _sanitize_job_name(long_name)
+        assert len(result) == MAX_RULE_NAME_LENGTH
+        # Should be truncated with suffix
+        assert result.endswith(TRUNCATION_SUFFIX)
+        expected = "a" * (MAX_RULE_NAME_LENGTH - len(TRUNCATION_SUFFIX)) + TRUNCATION_SUFFIX
+        assert result == expected
+
+    def test_truncation_strips_trailing_separator(self):
+        """Truncation should not leave trailing underscores or hyphens before suffix."""
+        # Create a name that would have _ at truncation point
+        name = "a" * 75 + "_b" * 20
+        result = _sanitize_job_name(name)
+        assert len(result) <= MAX_RULE_NAME_LENGTH
+        assert result.endswith(TRUNCATION_SUFFIX)
+        # Check no trailing separator before the suffix
+        without_suffix = result[:-len(TRUNCATION_SUFFIX)]
+        assert not without_suffix.endswith("_")
+        assert not without_suffix.endswith("-")
+
+    def test_empty_name_returns_job(self):
+        """Empty or all-invalid names should return 'job' as fallback."""
+        assert _sanitize_job_name("") == "job"
+        assert _sanitize_job_name("...") == "job"
+        assert _sanitize_job_name("___") == "job"
+
+    def test_group_job_name_format(self):
+        """Test sanitization of typical GroupJob name format."""
+        # GroupJob.name format: "{groupid}_{rule1}_{rule2}_..."
+        group_name = "alignment_group_align_sort_index_mark_duplicates"
+        result = _sanitize_job_name(group_name)
+        assert result == group_name  # Should be unchanged if valid
+
+    def test_group_job_with_ellipsis(self):
+        """GroupJob names with '...' (from truncation) should be sanitized."""
+        # Snakemake adds '...' when >5 rules in group
+        name = "group_rule1_rule2_rule3_rule4_rule5_..."
+        result = _sanitize_job_name(name)
+        assert "..." not in result
+        assert "_" not in result[-1:]  # Should not end with _
+
+    def test_custom_max_length(self):
+        """Custom max_length parameter should be respected."""
+        name = "abcdefghij"
+        result = _sanitize_job_name(name, max_length=5)
+        # 5 - 2 (suffix) = 3 chars + suffix
+        assert result == "abc" + TRUNCATION_SUFFIX
+        assert len(result) == 5

--- a/tests/test_batch_job_builder.py
+++ b/tests/test_batch_job_builder.py
@@ -1587,3 +1587,91 @@ class TestSanitizeJobName:
         # Result is max_length + suffix = 7 chars
         assert result == "abcde" + TRUNCATION_SUFFIX
         assert len(result) == 5 + len(TRUNCATION_SUFFIX)
+
+
+# ---------------------------------------------------------------------------
+# Tests for _build_job_names integration
+# ---------------------------------------------------------------------------
+
+
+class TestBuildJobNamesIntegration:
+    """Tests that build_job_definition and preexisting path use _sanitize_job_name."""
+
+    def _make_builder_with_name(self, job_name: str) -> BatchJobBuilder:
+        """Create a builder with a custom job name for testing sanitization."""
+        settings = SimpleNamespace(
+            job_queue="test-queue",
+            job_role="arn:aws:iam::123456789:role/test-role",
+            tags=None,
+            task_timeout=None,
+            job_definition=None,
+        )
+        batch_client = MagicMock()
+        batch_client.describe_job_queues.return_value = {"jobQueues": []}
+        batch_client.register_job_definition.return_value = {
+            "jobDefinitionName": "snakejob-def-test",
+            "revision": 1,
+        }
+
+        job = MagicMock()
+        job.name = job_name
+        job.threads = 1
+        job.resources = {"_cores": 1, "mem_mb": 1024}
+
+        builder = BatchJobBuilder(
+            logger=MagicMock(),
+            job=job,
+            envvars={},
+            container_image="test-image:latest",
+            settings=settings,
+            job_command="snakemake ...",
+            batch_client=batch_client,
+        )
+        # Force EC2 platform to avoid Fargate rejection
+        builder._platform = "EC2"
+        return builder
+
+    def test_build_job_definition_sanitizes_dotted_name(self):
+        """build_job_definition should sanitize job names with invalid characters."""
+        builder = self._make_builder_with_name("rule.with.dots")
+        job_def, job_name = builder.build_job_definition()
+
+        # Dots should be replaced with underscores
+        assert "." not in job_name
+        assert "rule_with_dots" in job_name
+        # Job definition name should also be sanitized
+        call_args = builder.batch_client.register_job_definition.call_args
+        job_def_name = call_args.kwargs["jobDefinitionName"]
+        assert "." not in job_def_name
+        assert "rule_with_dots" in job_def_name
+
+    def test_build_job_definition_sanitizes_long_name(self):
+        """build_job_definition should truncate overly long job names."""
+        long_name = "a" * 100
+        builder = self._make_builder_with_name(long_name)
+        job_def, job_name = builder.build_job_definition()
+
+        # Should be truncated with suffix
+        assert TRUNCATION_SUFFIX in job_name
+        # Total job name should fit AWS Batch limit (128 chars)
+        assert len(job_name) <= 128
+
+    def test_preexisting_path_sanitizes_dotted_name(self):
+        """_submit_with_preexisting_definition should sanitize job names."""
+        builder = self._make_builder_with_name("rule.with.dots")
+        # Remove job_role to avoid validation error in preexisting path
+        builder.settings.job_role = None
+        builder.batch_client.submit_job.return_value = {
+            "jobId": "test-job-id",
+            "jobName": "test-job-name",
+        }
+
+        result = builder._submit_with_preexisting_definition(
+            "arn:aws:batch:us-east-1:123456789:job-definition/my-def:1"
+        )
+
+        # Check the jobName passed to submit_job
+        call_args = builder.batch_client.submit_job.call_args
+        submitted_job_name = call_args.kwargs["jobName"]
+        assert "." not in submitted_job_name
+        assert "rule_with_dots" in submitted_job_name

--- a/tests/test_batch_job_builder.py
+++ b/tests/test_batch_job_builder.py
@@ -1541,10 +1541,10 @@ class TestSanitizeJobName:
         """Names exceeding max length should be truncated with suffix."""
         long_name = "a" * 100
         result = _sanitize_job_name(long_name)
-        assert len(result) == MAX_RULE_NAME_LENGTH
-        # Should be truncated with suffix
+        # Truncated to max_length + suffix
+        assert len(result) == MAX_RULE_NAME_LENGTH + len(TRUNCATION_SUFFIX)
         assert result.endswith(TRUNCATION_SUFFIX)
-        expected = "a" * (MAX_RULE_NAME_LENGTH - len(TRUNCATION_SUFFIX)) + TRUNCATION_SUFFIX
+        expected = "a" * MAX_RULE_NAME_LENGTH + TRUNCATION_SUFFIX
         assert result == expected
 
     def test_truncation_strips_trailing_separator(self):
@@ -1552,7 +1552,7 @@ class TestSanitizeJobName:
         # Create a name that would have _ at truncation point
         name = "a" * 75 + "_b" * 20
         result = _sanitize_job_name(name)
-        assert len(result) <= MAX_RULE_NAME_LENGTH
+        assert len(result) <= MAX_RULE_NAME_LENGTH + len(TRUNCATION_SUFFIX)
         assert result.endswith(TRUNCATION_SUFFIX)
         # Check no trailing separator before the suffix
         without_suffix = result[:-len(TRUNCATION_SUFFIX)]
@@ -1584,6 +1584,6 @@ class TestSanitizeJobName:
         """Custom max_length parameter should be respected."""
         name = "abcdefghij"
         result = _sanitize_job_name(name, max_length=5)
-        # 5 - 2 (suffix) = 3 chars + suffix
-        assert result == "abc" + TRUNCATION_SUFFIX
-        assert len(result) == 5
+        # Result is max_length + suffix = 7 chars
+        assert result == "abcde" + TRUNCATION_SUFFIX
+        assert len(result) == 5 + len(TRUNCATION_SUFFIX)

--- a/tests/test_batch_job_builder.py
+++ b/tests/test_batch_job_builder.py
@@ -1584,9 +1584,9 @@ class TestSanitizeJobName:
         """Custom max_length parameter should be respected."""
         name = "abcdefghij"
         result = _sanitize_job_name(name, max_length=5)
-        # Result is max_length + suffix = 7 chars
-        assert result == "abcde" + TRUNCATION_SUFFIX
-        assert len(result) == 5 + len(TRUNCATION_SUFFIX)
+        # 5 - 2 (suffix) = 3 chars + suffix
+        assert result == "abc" + TRUNCATION_SUFFIX
+        assert len(result) == 5
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_batch_job_builder.py
+++ b/tests/test_batch_job_builder.py
@@ -1663,6 +1663,24 @@ class TestBuildJobNamesIntegration:
         assert job_def_name.startswith(f"snakejob-def-{expected_stem}-")
         assert len(job_def_name) <= AWS_BATCH_MAX_NAME_LENGTH
 
+    def test_build_job_definition_exact_max_length_passes(self):
+        """A rule name at exactly MAX_RULE_NAME_LENGTH should not be truncated."""
+        exact_name = "a" * MAX_RULE_NAME_LENGTH
+        builder = self._make_builder_with_name(exact_name)
+        job_def, job_name = builder.build_job_definition()
+
+        # Should NOT be truncated — no suffix appended
+        assert job_name.startswith(f"snakejob-{exact_name}-")
+        assert TRUNCATION_SUFFIX not in job_name
+        assert len(job_name) <= AWS_BATCH_MAX_NAME_LENGTH
+        # Job definition name should also pass without truncation
+        job_def_name = builder.batch_client.register_job_definition.call_args.kwargs[
+            "jobDefinitionName"
+        ]
+        assert job_def_name.startswith(f"snakejob-def-{exact_name}-")
+        assert TRUNCATION_SUFFIX not in job_def_name
+        assert len(job_def_name) <= AWS_BATCH_MAX_NAME_LENGTH
+
     def test_preexisting_path_sanitizes_dotted_name(self):
         """_submit_with_preexisting_definition should sanitize job names."""
         builder = self._make_builder_with_name("rule.with.dots")

--- a/tests/test_batch_job_builder.py
+++ b/tests/test_batch_job_builder.py
@@ -19,6 +19,7 @@ from snakemake_executor_plugin_aws_batch.batch_job_builder import (
     _sanitize_job_name,
     MAX_RULE_NAME_LENGTH,
     TRUNCATION_SUFFIX,
+    AWS_BATCH_MAX_NAME_LENGTH,
 )
 from snakemake_executor_plugin_aws_batch.constant import (
     BATCH_JOB_PLATFORM_CAPABILITIES,

--- a/tests/test_batch_job_builder.py
+++ b/tests/test_batch_job_builder.py
@@ -1541,10 +1541,10 @@ class TestSanitizeJobName:
         """Names exceeding max length should be truncated with suffix."""
         long_name = "a" * 100
         result = _sanitize_job_name(long_name)
-        # Truncated to max_length + suffix
-        assert len(result) == MAX_RULE_NAME_LENGTH + len(TRUNCATION_SUFFIX)
+        assert len(result) == MAX_RULE_NAME_LENGTH
+        # Should be truncated with suffix
         assert result.endswith(TRUNCATION_SUFFIX)
-        expected = "a" * MAX_RULE_NAME_LENGTH + TRUNCATION_SUFFIX
+        expected = "a" * (MAX_RULE_NAME_LENGTH - len(TRUNCATION_SUFFIX)) + TRUNCATION_SUFFIX
         assert result == expected
 
     def test_truncation_strips_trailing_separator(self):

--- a/tests/test_batch_job_builder.py
+++ b/tests/test_batch_job_builder.py
@@ -1652,9 +1652,15 @@ class TestBuildJobNamesIntegration:
         job_def, job_name = builder.build_job_definition()
 
         # Should be truncated with suffix
-        assert TRUNCATION_SUFFIX in job_name
-        # Total job name should fit AWS Batch limit (128 chars)
-        assert len(job_name) <= 128
+        expected_stem = "a" * (MAX_RULE_NAME_LENGTH - len(TRUNCATION_SUFFIX)) + TRUNCATION_SUFFIX
+        assert job_name.startswith(f"snakejob-{expected_stem}-")
+        assert len(job_name) <= AWS_BATCH_MAX_NAME_LENGTH
+        # The job definition name is the binding constraint (longer prefix)
+        job_def_name = builder.batch_client.register_job_definition.call_args.kwargs[
+            "jobDefinitionName"
+        ]
+        assert job_def_name.startswith(f"snakejob-def-{expected_stem}-")
+        assert len(job_def_name) <= AWS_BATCH_MAX_NAME_LENGTH
 
     def test_preexisting_path_sanitizes_dotted_name(self):
         """_submit_with_preexisting_definition should sanitize job names."""


### PR DESCRIPTION
AWS Batch job names must be <= 128 characters and contain only alphanumeric characters, hyphens, and underscores.

This becomes and issue especially for GroupJob names which can be long (format: {groupid}_{rule1}_{rule2}_...).
Furthermore, Snakemake truncates group names with more than 5 rules and appends '...' to the name which is not accepted by AWS batch because of the period.

This change:
- Adds _sanitize_job_name() helper function
- Replaces invalid characters (dots, colons, slashes, etc.) with underscores
- Collapses multiple consecutive underscores
- Truncates names exceeding 78 characters (leaving room for snakejob-def- prefix and UUID)
- Adds '-x' suffix to indicate truncation occurred
- Handles edge cases like empty names or all-invalid characters



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS Batch job and job definition naming compatibility.
  * Sanitized names by normalizing invalid characters, trimming separators, collapsing repeated underscores, and safely truncating long names.
  * Added a safe fallback for empty or fully invalid names.
  * Applied consistent naming across job registration and submission.
  * Expanded coverage for common and edge-case naming scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->